### PR TITLE
feat: 支持 macOS 受控端（launchd 服务、构建矩阵、发布校验）

### DIFF
--- a/docs/cli-release.md
+++ b/docs/cli-release.md
@@ -4,7 +4,7 @@
 
 ## 构建本地候选包
 
-使用项目声明的 Go 版本，构建 Linux amd64/arm64 的静态 CLI。输出目录必须为空：
+使用项目声明的 Go 版本，构建 Linux 与 macOS amd64/arm64 的静态 CLI。输出目录必须为空：
 
 ```sh
 python3 scripts/test-cli-installer.py
@@ -12,9 +12,9 @@ python3 scripts/build-cli-release.py --version v0.1.0-rc.1 --signing-key /secure
 python3 scripts/verify-cli-release.py artifacts/cli-v0.1.0-rc.1
 ```
 
-打包脚本仅编译 `cmd/herdrx`，不需要前端构建。压缩包固定包含 `herdrx`、`VERSION`、离线 README、MIT LICENSE 和第三方依赖声明，归档时间固定；清单使用当前 UTC 时间，重复构建需传入相同的 `--created-at YYYY-MM-DDTHH:MM:SSZ`；附件还包含安装脚本、SHA256SUMS、README-CLI.md、release.json、两种架构的 `.manifest.json` 、RELEASE-PUBLIC-KEY、LICENSE、第三方声明及 CycloneDX SBOM。release.json 记录源码提交和工作区是否有未提交内容。
+打包脚本仅编译 `cmd/herdrx`，不需要前端构建。压缩包固定包含 `herdrx`、`VERSION`、离线 README、MIT LICENSE 和第三方依赖声明，归档时间固定；清单使用当前 UTC 时间，重复构建需传入相同的 `--created-at YYYY-MM-DDTHH:MM:SSZ`；附件还包含安装脚本、SHA256SUMS、README-CLI.md、release.json、四个平台组合（linux/darwin × amd64/arm64）的 `.manifest.json`、RELEASE-PUBLIC-KEY、LICENSE、第三方声明及 CycloneDX SBOM。清单的 `goos` 字段区分平台，`internal/updater` 按 `runtime.GOOS`/`GOARCH` 精确匹配后才接受更新。release.json 记录源码提交和工作区是否有未提交内容。
 
-验证脚本先用源码固定公钥核验清单签名，再检查每个附件的校验和、压缩包成员、ELF 架构和二进制摘要，并在当前 Linux CPU 上运行 version/help/offline status。ARM64 ELF 检查不能代替在 ARM64 主机实际运行。
+验证脚本先用源码固定公钥核验清单签名，再检查每个附件的校验和、压缩包成员、二进制格式（Linux 校验 ELF 魔数与机器类型，macOS 校验 64 位小端 Mach-O 魔数与 CPU 类型）和二进制摘要，并在当前 OS/CPU 上运行 version/help/offline status。没有任何附件匹配当前 runner 时脚本报错而不是静默跳过——「没跑」和「跑过且通过」不能同形。格式检查不能代替在对应架构的主机上实际运行：ARM64 与 Intel Mac 的附件都需要各自实机验证。
 
 ## 发布流程
 
@@ -24,7 +24,7 @@ python3 scripts/verify-cli-release.py artifacts/cli-v0.1.0-rc.1
 
 1. 验证 Go modules、vet、全量测试、race 和安装器故障场景。
 2. 从 `cli-release` Environment Secret 读取发行私钥，校验其公钥与源码固定信任根一致，构建并签名两种架构的同一版本附件，保存 Actions artifact。
-3. 在 Linux x86_64 和 ARM64 runner 上分别验证附件并实际运行对应 CLI。
+3. 在 Linux x86_64 和 ARM64 runner 上分别验证附件并实际运行对应 CLI。macOS 附件目前只做格式与签名校验，未在 macOS runner 上实机运行；纳入 CI 需要增加 `macos-14`（ARM64）与 `macos-13`（x86_64）两个 runner。
 4. 检查版本标签与候选包记录的提交一致、源码干净、提交已进入 `main`，且同一提交的完整主分支 CI 已成功，再上传 GitHub Release 草稿。
 5. 下载全部草稿附件，与本次构建逐字节摘要核对，通过后才公开 Release。失败会保留草稿，用户安装页不会把草稿视为可用版本。
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,13 +22,15 @@ docker compose up -d --wait
 
 先安装并独立运行 Herdr，以运行 Herdr 的同一用户操作。网站「添加主机 → Tailcat 内网穿透」提供完整的三步引导：
 
-1. 复制页面的一行安装命令，从 [GitHub Releases](https://github.com/riba2534/herdrx/releases) 安装 `herdrx`；自动识别 Linux x86_64 / ARM64 并做 SHA-256 校验。
-2. 执行 `~/.local/bin/herdrx setup && ~/.local/bin/herdrx status`，确认用户后台服务就绪，再检查 `loginctl show-user "$(id -un)" --property=Linger`；需为 `Linger=yes`。未启用时执行 `loginctl enable-linger "$(id -un)"`，权限不足再加 sudo。
+1. 复制页面的一行安装命令，从 [GitHub Releases](https://github.com/riba2534/herdrx/releases) 安装 `herdrx`；自动识别 Linux / macOS 的 x86_64 / ARM64 并做 SHA-256 校验。
+2. 执行 `~/.local/bin/herdrx setup && ~/.local/bin/herdrx status`，确认用户后台服务就绪。Linux 再检查 `loginctl show-user "$(id -un)" --property=Linger`；需为 `Linger=yes`，未启用时执行 `loginctl enable-linger "$(id -un)"`，权限不足再加 sudo。macOS 的 LaunchAgent 依附图形登录会话：纯 SSH 登录的 Mac 没有 Aqua 会话，`launchctl` 无法加载 `gui` 域，需先在该机登录一次桌面；`setup` 会在这种情况下明确告警。
 3. 执行 `~/.local/bin/herdrx connect --plain`，在页面最后一步填写一次性绑定凭据并打开主机。
 
 所有复制命令、手动安装、PATH 设置、无 systemd 环境、升级及排障见 [Tailcat 接入教程](tailcat-quickstart.md)。网页的一行命令直接使用 GitHub Release 安装脚本，并将下载与安装固定到同一版本，只有预发布时也可直接安装。安装过程不依赖工作台或个人域名；后续命令直接使用安装路径，无需设置 PATH。
 
-已有自定义 unit 时 setup 拒绝覆盖；旧配置损坏或旧服务仍在运行时，迁移明确失败，不会创建替代身份。Linux amd64/arm64 的原生 systemd 生命周期、升级回滚和旧服务迁移已通过隔离 guest 验收；macOS 受控端完整服务支持不在首发范围。详见 [当前验收](release-validation-2026-09-07.md)。
+已有自定义 unit / plist 时 setup 拒绝覆盖；旧配置损坏或旧服务仍在运行时，迁移明确失败，不会创建替代身份。Linux amd64/arm64 的原生 systemd 生命周期、升级回滚和旧服务迁移已通过隔离 guest 验收，详见 [当前验收](release-validation-2026-09-07.md)。
+
+macOS 受控端使用 per-user LaunchAgent（`~/Library/LaunchAgents/com.riba2534.herdrx.plist`，标签 `com.riba2534.herdrx`），由 `launchctl` 在 `gui/<uid>` 域中管理，服务日志写入 `~/Library/Logs/herdrx.log`，`herdrx logs` 直接读取该文件（macOS 没有 journald）。Herdr 自身的 socket 按 Herdr 的实际位置解析（`${XDG_CONFIG_HOME:-~/.config}/herdr`），不使用 macOS 惯例的 `~/Library/Application Support`。macOS 的服务生命周期尚未纳入 CI，由人工在 Apple Silicon 上验证；Intel Mac 的附件按同一流程构建但未实机运行。
 
 ## 工作台自带中继
 

--- a/docs/tailcat-quickstart.md
+++ b/docs/tailcat-quickstart.md
@@ -2,7 +2,7 @@
 
 在浏览器中选择「添加主机 → Tailcat 内网穿透」，按「安装 CLI → 后台运行 → 绑定主机」完成接入。`herdrx` 是用 Go 编写的远程主机 CLI，负责后台访问服务和生成一次性绑定凭据。网站运行在工作台主机，以下命令全部在**远程主机**上、以运行 Herdr 的同一用户执行。
 
-支持 Linux x86_64（amd64）和 ARM64（arm64）；推荐使用提供 systemd 用户会话的常规 Linux 发行版。Herdr 需要自行安装并独立运行，参考 [Herdr 官方安装说明](https://herdr.dev/docs/install/)。herdrx 安装器不安装、升级或启动 Herdr。
+支持 Linux 与 macOS 的 x86_64（amd64）和 ARM64（arm64）。Linux 推荐使用提供 systemd 用户会话的常规发行版；macOS 使用 per-user LaunchAgent，需要该用户能登录桌面（见下文「后台运行」）。Herdr 需要自行安装并独立运行，参考 [Herdr 官方安装说明](https://herdr.dev/docs/install/)。herdrx 安装器不安装、升级或启动 Herdr。
 
 ## 1. 下载并安装 CLI
 
@@ -14,7 +14,9 @@
 |---|---|
 | `herdrx-linux-amd64.tar.gz` | Linux x86_64 |
 | `herdrx-linux-arm64.tar.gz` | Linux ARM64 |
-| `install-herdrx.sh` | 自动选择架构、校验并安装 CLI |
+| `herdrx-darwin-arm64.tar.gz` | macOS Apple Silicon |
+| `herdrx-darwin-amd64.tar.gz` | macOS Intel |
+| `install-herdrx.sh` | 自动选择系统与架构、校验并安装 CLI |
 | `SHA256SUMS` | 附件 SHA-256 校验值 |
 | `README-CLI.md` | 本教程的离线副本 |
 | `release.json` | 版本、源码提交及构建信息 |
@@ -59,9 +61,9 @@ export PATH="$HOME/.local/bin:$PATH"
 ~/.local/bin/herdrx setup && ~/.local/bin/herdrx status
 ```
 
-`setup` 检查 Herdr 路径、API 能力和已有守护进程，保存受控端身份，安装 `herdrx.service` 用户服务并等待它就绪。重复执行会保留已有身份与绑定。`status` 应显示 herdrx daemon「运行中」、Herdr 状态「ok」。Herdr 不在 PATH 中时用 `~/.local/bin/herdrx setup --herdr-bin /path/to/herdr` 指定实际路径。
+`setup` 检查 Herdr 路径、API 能力和已有守护进程，保存受控端身份，安装用户级后台服务（Linux 为 `herdrx.service`，macOS 为 LaunchAgent `com.riba2534.herdrx`）并等待它就绪。重复执行会保留已有身份与绑定。`status` 应显示 herdrx daemon「运行中」、Herdr 状态「ok」。Herdr 不在 PATH 中时用 `~/.local/bin/herdrx setup --herdr-bin /path/to/herdr` 指定实际路径。
 
-检查关闭 SSH 及开机后的保活设置：
+检查关闭 SSH 及开机后的保活设置。**Linux：**
 
 ```sh
 loginctl show-user "$(id -un)" --property=Linger
@@ -71,6 +73,12 @@ loginctl show-user "$(id -un)" --property=Linger
 
 ```sh
 loginctl enable-linger "$(id -un)"
+```
+
+**macOS：** LaunchAgent 依附图形登录会话，没有 linger 这一概念。只通过 SSH 登录、从未登录过桌面的 Mac 没有 Aqua 会话，`launchctl` 的 `gui/<uid>` 域不可用，`setup` 会明确告警而不是假装成功。在该机登录一次桌面后重新执行 `setup` 即可。确认服务已加载：
+
+```sh
+launchctl print "gui/$(id -u)/com.riba2534.herdrx" | head -5
 ```
 
 服务管理与排查：
@@ -83,7 +91,9 @@ loginctl enable-linger "$(id -un)"
 ~/.local/bin/herdrx service restart
 ```
 
-没有 systemd 用户会话时，执行 `~/.local/bin/herdrx setup --skip-service`，再用你自己的进程管理器运行 `~/.local/bin/herdrx serve`。直接在前台执行 serve 后关闭终端，会中断 Tailcat 访问。无法配置保活时也可以使用网站的 SSH 接入。
+`herdrx logs` 在 Linux 读取 journald，在 macOS 读取 LaunchAgent 的输出文件 `~/Library/Logs/herdrx.log`。
+
+没有 systemd 用户会话（或 macOS 上无法使用 `gui` 域）时，执行 `~/.local/bin/herdrx setup --skip-service`，再用你自己的进程管理器运行 `~/.local/bin/herdrx serve`。直接在前台执行 serve 后关闭终端，会中断 Tailcat 访问。无法配置保活时也可以使用网站的 SSH 接入。
 
 ## 3. 绑定主机
 

--- a/install-herdrx.sh
+++ b/install-herdrx.sh
@@ -19,8 +19,9 @@ if [ "$herdrx_version" != latest ] && ! valid_version "$herdrx_version"; then
   echo 'Version must be latest or a release tag such as v0.1.0' >&2; exit 2
 fi
 case "$(uname -s)" in
-  Linux) ;;
-  *) echo 'This installer supports Linux. Use SSH access on other remote-host systems.' >&2; exit 1 ;;
+  Linux) herdrx_os=linux ;;
+  Darwin) herdrx_os=darwin ;;
+  *) echo 'This installer supports Linux and macOS. Use SSH access on other remote-host systems.' >&2; exit 1 ;;
 esac
 case "$(uname -m)" in
   x86_64|amd64) herdrx_arch=amd64 ;;
@@ -54,7 +55,7 @@ if [ "$herdrx_version" = latest ]; then
 else
   herdrx_download="$herdrx_repo/releases/download/$herdrx_version"
 fi
-herdrx_archive="herdrx-linux-$herdrx_arch.tar.gz"
+herdrx_archive="herdrx-$herdrx_os-$herdrx_arch.tar.gz"
 download() {
   curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --connect-timeout 15 --max-time 180 "$herdrx_download/$1" -o "$herdrx_tmp/$1"
 }

--- a/internal/agent/commands.go
+++ b/internal/agent/commands.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/riba2534/herdrx/internal/herdrpaths"
 	"github.com/riba2534/herdrx/internal/secure"
 	"github.com/riba2534/herdrx/internal/terminalgeometry"
 )
@@ -114,11 +115,10 @@ func configPathOutput() string {
 }
 
 func allowedSocket(path string) bool {
-	configDir, err := os.UserConfigDir()
+	root, err := herdrpaths.HerdrDir()
 	if err != nil {
 		return false
 	}
-	root := filepath.Join(configDir, "herdr")
 	clean := filepath.Clean(path)
 	relative, err := filepath.Rel(root, clean)
 	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {

--- a/internal/agent/sshserver.go
+++ b/internal/agent/sshserver.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/riba2534/herdrx/internal/herdrpaths"
 	"github.com/riba2534/herdrx/internal/secure"
 	"golang.org/x/crypto/ssh"
 )
@@ -272,7 +273,7 @@ func sendExitStatus(channel ssh.Channel, status uint32) {
 }
 
 func stagingDir() (string, error) {
-	cacheDir, err := os.UserCacheDir()
+	cacheDir, err := herdrpaths.CacheRoot()
 	if err != nil || cacheDir == "" {
 		cacheDir = filepath.Join(os.TempDir(), "herdrx-staging")
 	} else {

--- a/internal/agent/sshserver_test.go
+++ b/internal/agent/sshserver_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/riba2534/herdrx/internal/secure"
+	"github.com/riba2534/herdrx/internal/testpaths"
 	"github.com/tailscale/tailcat"
 	"golang.org/x/crypto/ssh"
 )
@@ -38,7 +39,7 @@ func setupTestSSH(t *testing.T, paired bool, revoked bool) (string, *SSHServer, 
 		t.Fatalf("parse host public key: %v", err)
 	}
 
-	tempDir := t.TempDir()
+	tempDir := testpaths.ShortTempDir(t)
 	configPath := filepath.Join(tempDir, "config.json")
 
 	node := tailcat.NewPrivateKey()
@@ -100,7 +101,7 @@ func dialLocalTCP(t *testing.T, server *SSHServer, clientConfig *ssh.ClientConfi
 }
 
 func TestStreamLocal_PairedGateControlAndPass(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := testpaths.ShortTempDir(t)
 	t.Setenv("XDG_CONFIG_HOME", tempDir)
 	herdrDir := filepath.Join(tempDir, "herdr")
 	if err := os.MkdirAll(herdrDir, 0o700); err != nil {
@@ -478,11 +479,7 @@ func TestClientSocketPairingRoleAndRevocation(t *testing.T) {
 		t.Run(suffix, func(t *testing.T) {
 			// Keep the Unix path below sockaddr_un's limit, and isolate XDG from
 			// every real Herdr session on the machine running this test.
-			dir, err := os.MkdirTemp("", "herdrx-socket-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Cleanup(func() { _ = os.RemoveAll(dir) })
+			dir := testpaths.ShortTempDir(t)
 			t.Setenv("XDG_CONFIG_HOME", dir)
 			path := filepath.Join(dir, "herdr", suffix)
 			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -593,7 +590,7 @@ func TestClientSocketPairingRoleAndRevocation(t *testing.T) {
 // TestHerdrBinCustomPathExec_WithSpaces 验证配置中的 HerdrBin 绝对路径被真实用于 SSH terminal 命令执行，
 // 且路径带空格或非标准路径时能安全调用
 func TestHerdrBinCustomPathExec_WithSpaces(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := testpaths.ShortTempDir(t)
 	spacedDir := filepath.Join(tempDir, "custom herdr bin with space")
 	if err := os.MkdirAll(spacedDir, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)

--- a/internal/agentcli/cli.go
+++ b/internal/agentcli/cli.go
@@ -271,7 +271,7 @@ func runSetup(args []string, stdout, stderr io.Writer, env Environment, defaultC
 		if instRes.LingerWarning != "" {
 			fmt.Fprintf(stdout, "注意: %s\n", instRes.LingerWarning)
 		} else {
-			fmt.Fprintln(stdout, "开机与登出保活: 已启用 (loginctl linger ok)")
+			fmt.Fprintln(stdout, layoutFor(runtime.GOOS, env).KeepAliveOK)
 		}
 	}
 
@@ -368,7 +368,7 @@ func runConnect(args []string, stdout, stderr io.Writer, env Environment, defaul
 
 	fmt.Fprintf(stdout, "主机：%s\n", hName)
 	fmt.Fprintln(stdout, "Herdr：可用")
-	fmt.Fprintln(stdout, "herdrx 进程：运行中；开机与登出保活请按安装引导检查 loginctl linger")
+	fmt.Fprintf(stdout, "herdrx 进程：运行中；%s\n", layoutFor(runtime.GOOS, env).KeepAliveCheck)
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "请在网站中选择：添加主机 → Tailcat 内网穿透 → 绑定主机")
 	fmt.Fprintln(stdout, "粘贴以下连接字符串（10 分钟内有效，只能绑定一次）：")
@@ -609,24 +609,25 @@ func runService(args []string, stdout, stderr io.Writer, env Environment, defaul
 	if runner == nil {
 		runner = NewRealServiceRunner()
 	}
+	label := ServiceLabel(env)
 
 	switch args[0] {
 	case "start":
-		if err := runner.EnableAndStart("herdrx.service"); err != nil {
+		if err := runner.EnableAndStart(label); err != nil {
 			fmt.Fprintf(stderr, "service start: %v\n", err)
 			return 1
 		}
 		fmt.Fprintln(stdout, "herdrx service started")
 		return 0
 	case "stop":
-		if err := runner.Stop("herdrx.service"); err != nil {
+		if err := runner.Stop(label); err != nil {
 			fmt.Fprintf(stderr, "service stop: %v\n", err)
 			return 1
 		}
 		fmt.Fprintln(stdout, "herdrx service stopped")
 		return 0
 	case "restart":
-		if err := runner.Restart("herdrx.service"); err != nil {
+		if err := runner.Restart(label); err != nil {
 			fmt.Fprintf(stderr, "service restart: %v\n", err)
 			return 1
 		}
@@ -912,6 +913,11 @@ func runLogs(args []string, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	// macOS 的 LaunchAgent 把 stdout/stderr 写入 ~/Library/Logs/herdrx.log，
+	// 没有 journald，改用 tail 读同一个文件。
+	if runtime.GOOS == "darwin" {
+		return runLaunchdLogs(*follow, *lines, stdout, stderr)
+	}
 	cmdArgs := []string{"--user", "-u", "herdrx.service", "-n", fmt.Sprintf("%d", *lines), "--no-pager"}
 	if *follow {
 		cmdArgs = append(cmdArgs, "-f")
@@ -921,6 +927,26 @@ func runLogs(args []string, stdout, stderr io.Writer) int {
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(stderr, "logs failed: %v\nuse: journalctl --user -u herdrx.service\nthis command does not stop Herdr\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runLaunchdLogs(follow bool, lines int, stdout, stderr io.Writer) int {
+	path := launchdLogPath()
+	if _, err := os.Stat(path); err != nil {
+		fmt.Fprintf(stderr, "logs failed: %v\nthe service writes to %s after herdrx setup\nthis command does not stop Herdr\n", err, path)
+		return 1
+	}
+	cmdArgs := []string{"-n", fmt.Sprintf("%d", lines)}
+	if follow {
+		cmdArgs = append(cmdArgs, "-f")
+	}
+	cmd := exec.Command("tail", append(cmdArgs, path)...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(stderr, "logs failed: %v\nuse: tail -f %s\nthis command does not stop Herdr\n", err, path)
 		return 1
 	}
 	return 0

--- a/internal/agentcli/config.go
+++ b/internal/agentcli/config.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -286,7 +287,7 @@ func MigrateFromLegacy(env Environment, targetConfigPath string) (Config, bool, 
 }
 
 func disableInactiveLegacyService(env Environment, configPath string) error {
-	unitPath := filepath.Join(filepath.Dir(filepath.Dir(configPath)), "systemd", "user", "herdrx-agent.service")
+	unitPath, label, markers := legacyServiceLayout(runtime.GOOS, env, configPath)
 	raw, err := os.ReadFile(unitPath)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -294,7 +295,14 @@ func disableInactiveLegacyService(env Environment, configPath string) error {
 	if err != nil {
 		return err
 	}
-	if !strings.Contains(string(raw), "Description=herdrx tailcat agent") && !strings.Contains(string(raw), "Description=herdrx remote access agent") {
+	generated := false
+	for _, marker := range markers {
+		if strings.Contains(string(raw), marker) {
+			generated = true
+			break
+		}
+	}
+	if !generated {
 		return errors.New("legacy service is customized; disable it explicitly before migrating")
 	}
 	runner := env.ServiceRunner
@@ -305,15 +313,35 @@ func disableInactiveLegacyService(env Environment, configPath string) error {
 	if !ok {
 		return errors.New("service manager cannot verify the legacy service state")
 	}
-	active, err := inspector.IsActive("herdrx-agent.service")
+	active, err := inspector.IsActive(label)
 	if err != nil {
 		return err
 	}
 	if active {
-		return errors.New("legacy service is still running; run systemctl --user stop herdrx-agent.service before migrating")
+		return fmt.Errorf("legacy service is still running; run %s before migrating", legacyStopHint(runtime.GOOS, label))
 	}
-	if err := runner.DisableAndStop("herdrx-agent.service"); err != nil {
+	if err := runner.DisableAndStop(label); err != nil {
 		return fmt.Errorf("disable legacy autostart before migration: %w", err)
 	}
 	return nil
+}
+
+// legacyServiceLayout 给出旧版受控端在该平台的单元位置、标识与生成物判据。
+// 旧版在 Linux 用 systemd user unit，在 macOS 用 LaunchAgent。
+func legacyServiceLayout(goos string, env Environment, configPath string) (unitPath, label string, markers []string) {
+	if goos == "darwin" {
+		label = "com.riba2534.herdrx-agent"
+		return filepath.Join(env.HomeDir, "Library", "LaunchAgents", label+".plist"), label,
+			[]string{"<string>" + label + "</string>"}
+	}
+	return filepath.Join(filepath.Dir(filepath.Dir(configPath)), "systemd", "user", "herdrx-agent.service"),
+		"herdrx-agent.service",
+		[]string{"Description=herdrx tailcat agent", "Description=herdrx remote access agent"}
+}
+
+func legacyStopHint(goos, label string) string {
+	if goos == "darwin" {
+		return fmt.Sprintf("launchctl bootout gui/$(id -u)/%s", label)
+	}
+	return "systemctl --user stop " + label
 }

--- a/internal/agentcli/config_test.go
+++ b/internal/agentcli/config_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -348,11 +349,17 @@ func TestXDGLegacyMigrationDisablesAutostartAndPreservesRevocation(t *testing.T)
 	env := Environment{HomeDir: dir, ConfigDir: filepath.Join(dir, "xdg-config", "herdrx"), StateDir: filepath.Join(dir, "xdg-state", "herdrx"), ServiceRunner: runner}
 	legacy := filepath.Join(dir, "xdg-config", "herdrx-agent", "config.json")
 	cfg := newUpdateConfig(t, legacy)
-	unit := filepath.Join(dir, "xdg-config", "systemd", "user", "herdrx-agent.service")
+	// 旧版受控端在两个平台用不同的服务机制：Linux 是 systemd user unit，
+	// macOS 是 LaunchAgent。按本平台写夹具，否则迁移逻辑根本看不到这个服务。
+	unit, legacyLabel, unitMarkers := legacyServiceLayout(runtime.GOOS, env, legacy)
+	unitBody := "[Unit]\nDescription=herdrx tailcat agent\n"
+	if runtime.GOOS == "darwin" {
+		unitBody = "<plist><dict><key>Label</key>" + unitMarkers[0] + "</dict></plist>\n"
+	}
 	if err := os.MkdirAll(filepath.Dir(unit), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(unit, []byte("[Unit]\nDescription=herdrx tailcat agent\n"), 0o600); err != nil {
+	if err := os.WriteFile(unit, []byte(unitBody), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	target := filepath.Join(env.ConfigDir, "config.json")
@@ -372,7 +379,7 @@ func TestXDGLegacyMigrationDisablesAutostartAndPreservesRevocation(t *testing.T)
 	}
 	found := false
 	for _, call := range runner.Calls {
-		if call == "DisableAndStop:herdrx-agent.service" {
+		if call == "DisableAndStop:"+legacyLabel {
 			found = true
 		}
 	}

--- a/internal/agentcli/endpoint_test.go
+++ b/internal/agentcli/endpoint_test.go
@@ -150,7 +150,7 @@ func TestDERPConfigRejectsMalformedDataAndProbeChecksProtocol(t *testing.T) {
 func TestSetupDERPConfigIsRepeatableAndCannotMoveActiveBinding(t *testing.T) {
 	dir := shortTempDir(t)
 	bin, _ := createMockHerdrFixture(t, dir, filepath.Join(dir, "fixture-config"))
-	env := Environment{HomeDir: dir, ConfigDir: filepath.Join(dir, "config"), RuntimeDir: filepath.Join(dir, "run"), HerdrBin: bin}
+	env := Environment{HomeDir: dir, ConfigDir: filepath.Join(dir, "config"), RuntimeDir: filepath.Join(dir, "run"), HerdrBin: bin, CommandRunner: fixtureCommandRunner}
 	configPath := filepath.Join(env.ConfigDir, "config.json")
 	regionPath := filepath.Join(dir, "derp.json")
 	region := []byte(`{"RegionID":7,"Nodes":[{"Name":"relay","HostName":"203.0.113.20","STUNPort":-1}]}`)

--- a/internal/agentcli/endpoint_test.go
+++ b/internal/agentcli/endpoint_test.go
@@ -31,11 +31,7 @@ func TestEndpointMigrationKeepsIdentityAcrossDaemonRestart(t *testing.T) {
 		}
 	}
 	defer tunnel.DefaultSSRFValidator.ClearAllowed()
-	dir, err := os.MkdirTemp("", "herdrx-endpoint-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := shortTempDir(t)
 	node := tailcat.NewPrivateKey()
 	node.Public.Region = []*tailcfg.DERPRegion{oldMap.Regions[1]}
 	hostPrivate, hostPublic, err := secure.GenerateSSHKey("endpoint-root")
@@ -152,11 +148,7 @@ func TestDERPConfigRejectsMalformedDataAndProbeChecksProtocol(t *testing.T) {
 }
 
 func TestSetupDERPConfigIsRepeatableAndCannotMoveActiveBinding(t *testing.T) {
-	dir, err := os.MkdirTemp("", "herdrx-setup-region-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := shortTempDir(t)
 	bin, _ := createMockHerdrFixture(t, dir, filepath.Join(dir, "fixture-config"))
 	env := Environment{HomeDir: dir, ConfigDir: filepath.Join(dir, "config"), RuntimeDir: filepath.Join(dir, "run"), HerdrBin: bin}
 	configPath := filepath.Join(env.ConfigDir, "config.json")

--- a/internal/agentcli/enrollment_e2e_test.go
+++ b/internal/agentcli/enrollment_e2e_test.go
@@ -173,7 +173,7 @@ func waitDaemonReady(t *testing.T, runtimeDir, configPath string, expectedPID in
 // 当前生产实现截取 node.Public.Addr()[:8]（由于 Tailcat v0.6 紧凑地址前缀为固定 CBOR 头 "tcpGFwWC"），
 // 必定生成完全相同的 SetupID 导致碰撞失败 (exit code 1)！
 func TestSetup_AgentIDUniquenessAcrossInstances(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := shortTempDir(t)
 	binDir := filepath.Join(tempDir, "bin")
 	if err := os.MkdirAll(binDir, 0o700); err != nil {
 		t.Fatalf("mkdir bin dir: %v", err)
@@ -250,7 +250,7 @@ func TestSetup_AgentIDUniquenessAcrossInstances(t *testing.T) {
 // 外部 Controller 经由真实临时端点 prepare -> 生产代码自动拉起正式端点 ->
 // 真实 Ed25519 签名 commit -> 正式通道执行 Herdr 命令 (stdin->stdout) 与真实 streamlocal 双向数据交互。
 func TestCLI_ConnectPrepareCommitAndHerdrIO_FullPipeline(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := shortTempDir(t)
 	binDir := filepath.Join(tempDir, "bin")
 	if err := os.MkdirAll(binDir, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -583,7 +583,7 @@ func TestCLI_ConnectPrepareCommitAndHerdrIO_FullPipeline(t *testing.T) {
 // 严格检验守护进程能否从持久化材料恢复正式端点与客户端通信。
 // 在当前生产实现下，runServe 重启时未恢复两阶段 formal Server，此测试将必然在重启拨号时触发超时失败，直接揭穿缺陷！
 func TestCLI_CrashRecovery_PreparedRestart(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := shortTempDir(t)
 	binDir := filepath.Join(tempDir, "bin")
 	if err := os.MkdirAll(binDir, 0o700); err != nil {
 		t.Fatalf("mkdir bin: %v", err)
@@ -922,7 +922,7 @@ func TestCLI_CrashRecovery_PreparedRestart(t *testing.T) {
 // 严格检验守护进程能否从磁盘恢复正式端点与有效 SSH 凭据，并执行真实 Herdr IO。
 // 在当前生产实现下，runServe 重启时未恢复两阶段 active formal Server，必然触发恢复失败！
 func TestCLI_CrashRecovery_ActiveRestart(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := shortTempDir(t)
 	binDir := filepath.Join(tempDir, "bin")
 	if err := os.MkdirAll(binDir, 0o700); err != nil {
 		t.Fatalf("mkdir bin: %v", err)
@@ -1327,7 +1327,7 @@ func TestCLI_CrashRecovery_ActiveRestart(t *testing.T) {
 
 // TestCLI_Security_IdempotencyAndConflictAndReject 测试准备幂等、冲突拒绝、未授权公钥拦截与已激活 commit 重试
 func TestCLI_Security_IdempotencyAndConflictAndReject(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := shortTempDir(t)
 	binDir := filepath.Join(tempDir, "bin")
 	if err := os.MkdirAll(binDir, 0o700); err != nil {
 		t.Fatalf("os.MkdirAll: %v", err)
@@ -1651,7 +1651,7 @@ func TestCLI_Security_IdempotencyAndConflictAndReject(t *testing.T) {
 
 // TestCLI_RevokeAndReEnroll 测试 unpair 真实连接强断与撤销后新 connect 全新周期绑定
 func TestCLI_RevokeAndReEnroll(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := shortTempDir(t)
 	binDir := filepath.Join(tempDir, "bin")
 	if err := os.MkdirAll(binDir, 0o700); err != nil {
 		t.Fatalf("os.MkdirAll: %v", err)

--- a/internal/agentcli/env.go
+++ b/internal/agentcli/env.go
@@ -78,7 +78,12 @@ func RunBoundedCommand(ctx context.Context, timeout time.Duration, maxBytes int6
 // DefaultEnv 返回当前运行时的真实环境依赖，默认命令执行器接入 3s 超时与 1MB 流式上限
 func DefaultEnv() Environment {
 	home, _ := os.UserHomeDir()
-	configRoot, _ := os.UserConfigDir()
+	// XDG_CONFIG_HOME 必须优先于平台惯例：os.UserConfigDir() 在 macOS 上直接
+	// 忽略它，会让 --config 之外的路径覆盖失效，也让隔离测试落到真实用户目录。
+	configRoot := xdgDirectory("XDG_CONFIG_HOME", "")
+	if configRoot == "" {
+		configRoot, _ = os.UserConfigDir()
+	}
 	if configRoot == "" {
 		configRoot = filepath.Join(home, ".config")
 	}

--- a/internal/agentcli/legacy_test.go
+++ b/internal/agentcli/legacy_test.go
@@ -22,7 +22,7 @@ import (
 // 真实 SSH 客户端拨号发送 confirm-pair -> IPC status 实时变为 paired ->
 // IPC unpair 撤销 -> 验证连接断开与状态更新
 func TestLegacy_FullWorkflowThroughIPCAndSSH(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := shortTempDir(t)
 	env := Environment{
 		ConfigDir:  tempDir,
 		RuntimeDir: tempDir,

--- a/internal/agentcli/onboarding_test.go
+++ b/internal/agentcli/onboarding_test.go
@@ -13,11 +13,8 @@ func TestSetupMigrationFailureDoesNotGenerateIdentity(t *testing.T) {
 	for _, running := range []bool{false, true} {
 		t.Run(map[bool]string{false: "invalid legacy config", true: "running legacy service"}[running], func(t *testing.T) {
 			// Keep Unix socket paths below the platform's sockaddr limit.
-			dir, err := os.MkdirTemp("", "herdrx-onboard-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Cleanup(func() { _ = os.RemoveAll(dir) })
+			// macOS 的 TMPDIR 本身就有 49 个字符，MkdirTemp("") 不足以保证够短。
+			dir := shortTempDir(t)
 			legacy := filepath.Join(dir, ".config", "herdrx-agent", "config.json")
 			if err := os.MkdirAll(filepath.Dir(legacy), 0o700); err != nil {
 				t.Fatal(err)

--- a/internal/agentcli/preflight_test.go
+++ b/internal/agentcli/preflight_test.go
@@ -25,16 +25,28 @@ func TestPreflight_Missing(t *testing.T) {
 
 // TestPreflight_BinTrueRejected 严格验证 /bin/true 绝不可被误判为有效 Herdr
 func TestPreflight_BinTrueRejected(t *testing.T) {
+	// macOS 只有 /usr/bin/true，Linux 通常是 /bin/true；按实际存在的位置取，
+	// 否则这条断言会退化成「文件不存在」而不再检验兼容性判定。
+	truePath := ""
+	for _, candidate := range []string{"/bin/true", "/usr/bin/true"} {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			truePath = candidate
+			break
+		}
+	}
+	if truePath == "" {
+		t.Skip("no true(1) binary available")
+	}
 	env := Environment{
-		HerdrBin: "/bin/true",
+		HerdrBin: truePath,
 		CommandRunner: func(name string, args ...string) ([]byte, error) {
-			// /bin/true 无论什么参数都退出码 0 且输出为空
+			// true 无论什么参数都退出码 0 且输出为空
 			return []byte{}, nil
 		},
 	}
 	res := RunPreflight(env)
 	if res.Status != PreflightIncompatible {
-		t.Fatalf("expected /bin/true to be rejected as incompatible, got status: %s (details: %s)", res.Status, res.Details)
+		t.Fatalf("expected %s to be rejected as incompatible, got status: %s (details: %s)", truePath, res.Status, res.Details)
 	}
 }
 

--- a/internal/agentcli/recovery_regression_test.go
+++ b/internal/agentcli/recovery_regression_test.go
@@ -30,7 +30,7 @@ type enrollmentProcess struct {
 
 func newEnrollmentProcess(t *testing.T) *enrollmentProcess {
 	t.Helper()
-	dir := t.TempDir()
+	dir := shortTempDir(t)
 	f := &enrollmentProcess{t: t, dir: dir, bin: filepath.Join(dir, "herdrx"), config: filepath.Join(dir, "c", "agent.json"), runtime: filepath.Join(dir, "r")}
 	buildCLI(t, f.bin)
 	fakeHerdr, _ := createMockHerdrFixture(t, dir, filepath.Join(dir, "c"))

--- a/internal/agentcli/service.go
+++ b/internal/agentcli/service.go
@@ -216,7 +216,11 @@ func launchdDomain() string { return fmt.Sprintf("gui/%d", os.Getuid()) }
 func launchdTarget(label string) string { return launchdDomain() + "/" + label }
 
 func runLaunchctl(timeout time.Duration, args ...string) ([]byte, error) {
-	out, err := RunBoundedCommand(context.Background(), timeout, 64<<10, "launchctl", args...)
+	return runLaunchctlLimited(timeout, 64<<10, args...)
+}
+
+func runLaunchctlLimited(timeout time.Duration, maxBytes int64, args ...string) ([]byte, error) {
+	out, err := RunBoundedCommand(context.Background(), timeout, maxBytes, "launchctl", args...)
 	if err != nil {
 		return out, fmt.Errorf("launchctl %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 	}
@@ -226,11 +230,17 @@ func runLaunchctl(timeout time.Duration, args ...string) ([]byte, error) {
 // CheckLinger 在 macOS 上检查 gui 域是否可用。launchd 的 LaunchAgent 依附图形
 // 登录会话：纯 SSH 登录的机器没有 Aqua 会话，bootstrap 会失败，行为上等价于
 // Linux 缺少 linger —— 登出/未登录时后台服务不存活，所以复用同一个告警位。
+//
+// 不能用 `launchctl print gui/<uid>` 判断：它会把域里所有服务全部打印出来，
+// 正常 Mac 上轻易超过 10 万字节，撞上输出上限后会被误判成「没有图形会话」，
+// 于是每台健康的 Mac 都收到一条错误告警。`launchctl managername` 只输出一行
+// （有图形会话时为 Aqua），是这里真正要问的问题。
 func (r *LaunchdServiceRunner) CheckLinger(username string) (bool, error) {
-	if _, err := runLaunchctl(5*time.Second, "print", launchdDomain()); err != nil {
+	out, err := runLaunchctl(5*time.Second, "managername")
+	if err != nil {
 		return false, err
 	}
-	return true, nil
+	return strings.TrimSpace(string(out)) == "Aqua", nil
 }
 
 // DaemonReload launchd 没有全局 reload：plist 的变化在 bootout+bootstrap 时生效，
@@ -276,7 +286,9 @@ func (r *LaunchdServiceRunner) DisableAndStop(serviceName string) error {
 }
 
 func (r *LaunchdServiceRunner) IsActive(serviceName string) (bool, error) {
-	out, err := runLaunchctl(5*time.Second, "print", launchdTarget(serviceName))
+	// 单个服务的 print 通常 3KB 左右，但环境变量多时会明显变大；给足上限，
+	// 避免「输出超限」被下面的 launchdNotLoaded 误判成「服务不存在」。
+	out, err := runLaunchctlLimited(5*time.Second, 1<<20, "print", launchdTarget(serviceName))
 	if err != nil {
 		if launchdNotLoaded(err) {
 			return false, nil

--- a/internal/agentcli/service.go
+++ b/internal/agentcli/service.go
@@ -1,13 +1,16 @@
 package agentcli
 
 import (
+	"bytes"
 	"context"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -24,9 +27,86 @@ type ServiceRunner interface {
 	RemoveUnitFile(path string) error
 }
 
+// serviceLayout 描述单个平台的服务定义：标识、单元位置与「本单元由 herdrx 生成」
+// 的判据。平台差异集中在这里，InstallService 等流程不再直接假设 systemd。
+type serviceLayout struct {
+	GOOS     string
+	Label    string
+	UnitPath string
+	// Marker 用于区分自动生成与用户自定义的单元；缺少它一律拒绝覆盖。
+	Marker string
+	// LingerHint 为空表示该平台不需要 linger 之类的登出保活设置。
+	LingerHint func(username string) string
+	// KeepAliveOK 是保活已就绪时展示给用户的说明。
+	KeepAliveOK string
+	// KeepAliveCheck 提示用户如何自查保活设置。
+	KeepAliveCheck string
+}
+
+const (
+	systemdUnitMarker = "Description=herdrx remote access agent"
+	launchdLabel      = "com.riba2534.herdrx"
+	// launchdPlistMarker 同时出现在生成的 plist 中，作为生成物判据。
+	launchdPlistMarker = "<string>" + launchdLabel + "</string>"
+)
+
+// layoutFor 按目标平台给出服务布局。goos 显式传入而非直接读 runtime.GOOS，
+// 这样两个平台的单元内容和路径都能在任意一种 CI 机器上被测试覆盖。
+func layoutFor(goos string, env Environment) serviceLayout {
+	switch goos {
+	case "darwin":
+		return serviceLayout{
+			GOOS:     goos,
+			Label:    launchdLabel,
+			UnitPath: filepath.Join(env.HomeDir, "Library", "LaunchAgents", launchdLabel+".plist"),
+			Marker:   launchdPlistMarker,
+			// LaunchAgent 随图形登录启动；纯 SSH 登录的 Mac 没有 Aqua 会话，
+			// 需要用户至少登录一次桌面，launchd 才会加载 gui 域。
+			LingerHint: func(string) string {
+				return "当前用户没有活动的图形登录会话，launchd 的 gui 域不可用，后台服务不会随登录自动启动。请在这台 Mac 上登录一次桌面后重新执行 herdrx setup"
+			},
+			KeepAliveOK:    "登录后自动启动: 已启用 (launchd LaunchAgent 已加载)",
+			KeepAliveCheck: "登录后自动启动请按安装引导检查 launchd LaunchAgent",
+		}
+	default:
+		return serviceLayout{
+			GOOS:     goos,
+			Label:    "herdrx.service",
+			UnitPath: systemdUnitPath(env),
+			Marker:   systemdUnitMarker,
+			LingerHint: func(username string) string {
+				return fmt.Sprintf("当前用户未开启 loginctl linger，SSH 登出后后台服务可能会被系统终止。建议执行: loginctl enable-linger %s", username)
+			},
+			KeepAliveOK:    "开机与登出保活: 已启用 (loginctl linger ok)",
+			KeepAliveCheck: "开机与登出保活请按安装引导检查 loginctl linger",
+		}
+	}
+}
+
+// Content 生成该平台的服务单元内容。
+func (l serviceLayout) Content(binaryPath, configPath, runtimeDir string) string {
+	if l.GOOS == "darwin" {
+		return GenerateLaunchdPlist(binaryPath, configPath, runtimeDir)
+	}
+	return GenerateSystemdUnit(binaryPath, configPath, runtimeDir)
+}
+
+// ConfigReference 返回单元内容中引用该配置路径时应出现的片段，用于确认
+// 待修复的单元指向同一身份。两个平台的引号/转义规则不同，所以由布局给出。
+func (l serviceLayout) ConfigReference(configPath string) string {
+	if l.GOOS == "darwin" {
+		return "<string>" + xmlEscapeText(configPath) + "</string>"
+	}
+	return " --config " + systemdArgument(configPath)
+}
+
 type RealServiceRunner struct{}
 
+// NewRealServiceRunner 按运行平台选择服务管理器实现。
 func NewRealServiceRunner() ServiceRunner {
+	if runtime.GOOS == "darwin" {
+		return &LaunchdServiceRunner{}
+	}
 	return &RealServiceRunner{}
 }
 
@@ -127,6 +207,121 @@ func (r *RealServiceRunner) RemoveUnitFile(path string) error {
 	return err
 }
 
+// LaunchdServiceRunner 用 launchctl 管理 macOS 的 per-user LaunchAgent。
+// 沿用旧版受控端已有的 gui/<uid> 域与 com.riba2534.herdrx-* 标签约定。
+type LaunchdServiceRunner struct{}
+
+func launchdDomain() string { return fmt.Sprintf("gui/%d", os.Getuid()) }
+
+func launchdTarget(label string) string { return launchdDomain() + "/" + label }
+
+func runLaunchctl(timeout time.Duration, args ...string) ([]byte, error) {
+	out, err := RunBoundedCommand(context.Background(), timeout, 64<<10, "launchctl", args...)
+	if err != nil {
+		return out, fmt.Errorf("launchctl %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+// CheckLinger 在 macOS 上检查 gui 域是否可用。launchd 的 LaunchAgent 依附图形
+// 登录会话：纯 SSH 登录的机器没有 Aqua 会话，bootstrap 会失败，行为上等价于
+// Linux 缺少 linger —— 登出/未登录时后台服务不存活，所以复用同一个告警位。
+func (r *LaunchdServiceRunner) CheckLinger(username string) (bool, error) {
+	if _, err := runLaunchctl(5*time.Second, "print", launchdDomain()); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// DaemonReload launchd 没有全局 reload：plist 的变化在 bootout+bootstrap 时生效，
+// 由 EnableAndStart 与 Restart 负责，这里无需动作。
+func (r *LaunchdServiceRunner) DaemonReload() error { return nil }
+
+func (r *LaunchdServiceRunner) EnableAndStart(serviceName string) error {
+	plist := launchdPlistPathForLabel(serviceName)
+	// 已加载时 bootstrap 会因 EEXIST 失败，先无条件 bootout 使其幂等。
+	_, _ = runLaunchctl(20*time.Second, "bootout", launchdTarget(serviceName))
+	if _, err := runLaunchctl(35*time.Second, "bootstrap", launchdDomain(), plist); err != nil {
+		return err
+	}
+	// bootstrap 只保证已加载；RunAtLoad 之外显式 kickstart 一次，让 setup 之后
+	// 立刻有进程，与 systemctl enable --now 的语义对齐。
+	_, err := runLaunchctl(35*time.Second, "kickstart", launchdTarget(serviceName))
+	return err
+}
+
+func (r *LaunchdServiceRunner) Stop(serviceName string) error {
+	_, err := runLaunchctl(35*time.Second, "bootout", launchdTarget(serviceName))
+	if err != nil && launchdNotLoaded(err) {
+		return nil
+	}
+	return err
+}
+
+func (r *LaunchdServiceRunner) Restart(serviceName string) error {
+	// -k 先杀掉正在运行的实例再拉起，等价于 systemctl restart。
+	_, err := runLaunchctl(35*time.Second, "kickstart", "-k", launchdTarget(serviceName))
+	if err == nil {
+		return nil
+	}
+	// 服务尚未加载时 kickstart 无对象可操作，退回完整加载路径。
+	if launchdNotLoaded(err) {
+		return r.EnableAndStart(serviceName)
+	}
+	return err
+}
+
+func (r *LaunchdServiceRunner) DisableAndStop(serviceName string) error {
+	return r.Stop(serviceName)
+}
+
+func (r *LaunchdServiceRunner) IsActive(serviceName string) (bool, error) {
+	out, err := runLaunchctl(5*time.Second, "print", launchdTarget(serviceName))
+	if err != nil {
+		if launchdNotLoaded(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	// 已加载但没有 pid 说明进程不在运行（例如 KeepAlive 退避中）。
+	return strings.Contains(string(out), "pid = "), nil
+}
+
+func (r *LaunchdServiceRunner) WriteUnitFile(path string, content []byte) error {
+	return (&RealServiceRunner{}).WriteUnitFile(path, content)
+}
+
+func (r *LaunchdServiceRunner) RemoveUnitFile(path string) error {
+	return (&RealServiceRunner{}).RemoveUnitFile(path)
+}
+
+// launchdNotLoaded 判断错误是否为「服务未加载」。launchctl 用 113
+// (Could not find service) / 3 (No such process) 表达这一类状态。
+func launchdNotLoaded(err error) bool {
+	text := err.Error()
+	return strings.Contains(text, "Could not find service") ||
+		strings.Contains(text, "No such process") ||
+		strings.Contains(text, "not find specified service")
+}
+
+func launchdPlistPathForLabel(label string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join("Library", "LaunchAgents", label+".plist")
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", label+".plist")
+}
+
+// launchdLogPath 是 LaunchAgent 的 stdout/stderr 落盘位置，也是 herdrx logs
+// 在 macOS 上读取的文件；两处必须一致，所以只在这里定义。
+func launchdLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join("Library", "Logs", "herdrx.log")
+	}
+	return filepath.Join(home, "Library", "Logs", "herdrx.log")
+}
+
 type InstallResult struct {
 	UnitPath      string `json:"unit_path"`
 	LingerEnabled bool   `json:"linger_enabled"`
@@ -162,7 +357,59 @@ func systemdArgument(value string) string {
 	return strconv.Quote(strings.NewReplacer("%", "%%", "$", "$$").Replace(value))
 }
 
-func serviceUnitPath(env Environment) string {
+// GenerateLaunchdPlist 构造 per-user LaunchAgent，语义对齐 systemd 单元：
+// 固定绝对路径、注入 PATH、崩溃后自动重启。
+func GenerateLaunchdPlist(binaryPath, configPath string, runtimeDirs ...string) string {
+	arguments := []string{binaryPath, "serve", "--config", configPath}
+	if len(runtimeDirs) > 0 && runtimeDirs[0] != "" {
+		arguments = append(arguments, "--runtime-dir", runtimeDirs[0])
+	}
+	var program strings.Builder
+	for _, argument := range arguments {
+		program.WriteString("\n    <string>" + xmlEscapeText(argument) + "</string>")
+	}
+	logPath := launchdLogPath()
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  ` + launchdPlistMarker + `
+  <key>ProgramArguments</key>
+  <array>` + program.String() + `
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>3</integer>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>` + xmlEscapeText(os.Getenv("PATH")) + `</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>` + xmlEscapeText(logPath) + `</string>
+  <key>StandardErrorPath</key>
+  <string>` + xmlEscapeText(logPath) + `</string>
+</dict>
+</plist>
+`
+}
+
+// xmlEscapeText 转义 plist 文本节点。路径由用户目录和配置派生，可能含 & < >。
+func xmlEscapeText(value string) string {
+	var buf bytes.Buffer
+	if err := xml.EscapeText(&buf, []byte(value)); err != nil {
+		return ""
+	}
+	return buf.String()
+}
+
+func systemdUnitPath(env Environment) string {
 	root := filepath.Join(env.HomeDir, ".config")
 	if env.ConfigDir != "" {
 		root = filepath.Dir(env.ConfigDir)
@@ -170,8 +417,13 @@ func serviceUnitPath(env Environment) string {
 	return filepath.Join(root, "systemd", "user", "herdrx.service")
 }
 
-// os.Executable resolves symlinks on Linux. Prefer the stable entrypoint that
-// actually refers to this executable, so subsequent service restarts upgrade.
+func serviceUnitPath(env Environment) string {
+	return layoutFor(runtime.GOOS, env).UnitPath
+}
+
+// os.Executable resolves symlinks on Linux and macOS alike. Prefer the stable
+// entrypoint that actually refers to this executable, so subsequent service
+// restarts upgrade.
 func resolveServiceExecutable(env Environment, executable string) string {
 	actual, err := os.Stat(executable)
 	if err != nil {
@@ -218,7 +470,9 @@ func InstallService(env Environment, binaryPath, configPath string) (*InstallRes
 		}
 	}
 
-	// 检查当前用户 linger 状态
+	// 检查后台服务在用户登出后能否存活：Linux 看 loginctl linger，
+	// macOS 看 launchd 的 gui 域是否可用。
+	layout := layoutFor(runtime.GOOS, env)
 	u, err := user.Current()
 	var lingerOk bool
 	if err == nil {
@@ -226,20 +480,20 @@ func InstallService(env Environment, binaryPath, configPath string) (*InstallRes
 	}
 
 	var warning string
-	if !lingerOk {
+	if !lingerOk && layout.LingerHint != nil {
 		username := "your-user"
 		if u != nil {
 			username = u.Username
 		}
-		warning = fmt.Sprintf("当前用户未开启 loginctl linger，SSH 登出后后台服务可能会被系统终止。建议执行: loginctl enable-linger %s", username)
+		warning = layout.LingerHint(username)
 	}
 
 	absBin = resolveServiceExecutable(env, absBin)
-	unitContent := GenerateSystemdUnit(absBin, absCfg, env.RuntimeDir)
-	unitPath := serviceUnitPath(env)
+	unitContent := layout.Content(absBin, absCfg, env.RuntimeDir)
+	unitPath := layout.UnitPath
 	unitChanged := false
 	if existing, err := os.ReadFile(unitPath); err == nil {
-		if !strings.Contains(string(existing), "Description=herdrx remote access agent") {
+		if !strings.Contains(string(existing), layout.Marker) {
 			return nil, fmt.Errorf("refusing to overwrite custom unit at %s", unitPath)
 		}
 		unitChanged = string(existing) != unitContent
@@ -248,16 +502,16 @@ func InstallService(env Environment, binaryPath, configPath string) (*InstallRes
 	}
 
 	if err := runner.WriteUnitFile(unitPath, []byte(unitContent)); err != nil {
-		return nil, fmt.Errorf("write systemd unit: %w", err)
+		return nil, fmt.Errorf("write service unit: %w", err)
 	}
 	if err := runner.DaemonReload(); err != nil {
-		return nil, fmt.Errorf("systemctl daemon-reload: %w", err)
+		return nil, fmt.Errorf("reload service manager: %w", err)
 	}
-	if err := runner.EnableAndStart("herdrx.service"); err != nil {
-		return nil, fmt.Errorf("systemctl enable --now: %w", err)
+	if err := runner.EnableAndStart(layout.Label); err != nil {
+		return nil, fmt.Errorf("enable and start service: %w", err)
 	}
 	if unitChanged {
-		if err := runner.Restart("herdrx.service"); err != nil {
+		if err := runner.Restart(layout.Label); err != nil {
 			return nil, fmt.Errorf("restart changed unit: %w", err)
 		}
 	}
@@ -267,14 +521,14 @@ func InstallService(env Environment, binaryPath, configPath string) (*InstallRes
 		LingerEnabled: lingerOk,
 		LingerWarning: warning,
 	}
-	if _, ok := runner.(*RealServiceRunner); ok {
+	if isRealServiceRunner(runner) {
 		sock := filepath.Join(env.RuntimeDir, "control.sock")
 		var status Readiness
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		callErr := clientCallIPCContext(ctx, sock, "GET", "/ready", absCfg, nil, &status)
 		cancel()
 		if !unitChanged && (callErr != nil || status.Version != Version) {
-			if err := runner.Restart("herdrx.service"); err != nil {
+			if err := runner.Restart(layout.Label); err != nil {
 				return result, fmt.Errorf("restart installed binary: %w", err)
 			}
 		}
@@ -299,15 +553,31 @@ func UninstallService(env Environment) error {
 		runner = NewRealServiceRunner()
 	}
 
-	unitPath := serviceUnitPath(env)
-	if err := runner.DisableAndStop("herdrx.service"); err != nil {
+	layout := layoutFor(runtime.GOOS, env)
+	if err := runner.DisableAndStop(layout.Label); err != nil {
 		return fmt.Errorf("stop and disable service: %w", err)
 	}
-	if err := runner.RemoveUnitFile(unitPath); err != nil {
+	if err := runner.RemoveUnitFile(layout.UnitPath); err != nil {
 		return fmt.Errorf("remove unit file: %w", err)
 	}
 	if err := runner.DaemonReload(); err != nil {
-		return fmt.Errorf("daemon-reload after uninstall: %w", err)
+		return fmt.Errorf("reload service manager after uninstall: %w", err)
 	}
 	return nil
+}
+
+// isRealServiceRunner 判断是否为真实的平台服务管理器（而非测试替身），
+// 只有这时才需要等待守护进程真正就绪。
+func isRealServiceRunner(runner ServiceRunner) bool {
+	switch runner.(type) {
+	case *RealServiceRunner, *LaunchdServiceRunner:
+		return true
+	default:
+		return false
+	}
+}
+
+// ServiceLabel 返回当前平台的服务标识，供命令行提示与服务管理子命令使用。
+func ServiceLabel(env Environment) string {
+	return layoutFor(runtime.GOOS, env).Label
 }

--- a/internal/agentcli/service_launchd_test.go
+++ b/internal/agentcli/service_launchd_test.go
@@ -1,0 +1,141 @@
+package agentcli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLaunchdServiceRunnerAgainstRealLaunchd 用真实的 launchctl 走一遍
+// bootstrap → kickstart → 查询 → bootout，确认生成的 plist 能被 launchd 接受、
+// 进程真的被拉起、幂等重复执行不报错、卸载后确实消失。
+//
+// 只在 macOS 且 gui 域可用时运行：CI 的 Linux runner 会跳过，纯 SSH 登录的 Mac
+// 也会跳过（那里没有 Aqua 会话，正是 setup 会告警的场景）。
+//
+// 用独立的 HOME 和独立标签，绝不碰这台机器上真实的 com.riba2534.herdrx 服务。
+func TestLaunchdServiceRunnerAgainstRealLaunchd(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchd is macOS-only")
+	}
+	if _, err := exec.LookPath("launchctl"); err != nil {
+		t.Skip("launchctl unavailable")
+	}
+	if ok, err := (&LaunchdServiceRunner{}).CheckLinger(""); err != nil || !ok {
+		t.Skipf("launchd gui domain unavailable (no desktop login session): ok=%v err=%v", ok, err)
+	}
+
+	home := shortTempDir(t)
+	t.Setenv("HOME", home)
+	agents := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(agents, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// 独立标签，避免与真实服务同名；同时确认测试自己不会留下残留。
+	label := "com.riba2534.herdrx-selftest"
+	marker := filepath.Join(home, "ran.txt")
+	plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>` + label + `</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>echo running &gt;&gt; ` + xmlEscapeText(marker) + `; sleep 30</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>
+`
+	path := filepath.Join(agents, label+".plist")
+	runner := &LaunchdServiceRunner{}
+	if err := runner.WriteUnitFile(path, []byte(plist)); err != nil {
+		t.Fatal(err)
+	}
+	// launchctl 以自己的权限读取 plist；0600 + 独立目录已足够，这里确认可读。
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = runLaunchctl(20*time.Second, "bootout", launchdTarget(label))
+	})
+
+	if err := runner.EnableAndStart(label); err != nil {
+		t.Fatalf("EnableAndStart against real launchd: %v", err)
+	}
+
+	// 进程确实被拉起：等 marker 文件出现，而不是只看 launchctl 的退出码。
+	deadline := time.Now().Add(15 * time.Second)
+	var ran bool
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(marker); err == nil && strings.Contains(string(data), "running") {
+			ran = true
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if !ran {
+		out, _ := runLaunchctl(5*time.Second, "print", launchdTarget(label))
+		t.Fatalf("service was loaded but never executed; launchctl print:\n%s", out)
+	}
+
+	active, err := runner.IsActive(label)
+	if err != nil {
+		t.Fatalf("IsActive: %v", err)
+	}
+	if !active {
+		t.Fatal("expected the freshly started service to report active")
+	}
+
+	// 幂等：EnableAndStart 再来一次不能因为 already loaded 而失败。
+	if err := runner.EnableAndStart(label); err != nil {
+		t.Fatalf("EnableAndStart must be idempotent: %v", err)
+	}
+	if err := runner.Restart(label); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+
+	if err := runner.DisableAndStop(label); err != nil {
+		t.Fatalf("DisableAndStop: %v", err)
+	}
+	if active, err := runner.IsActive(label); err != nil || active {
+		t.Fatalf("service still active after stop (active=%v, err=%v)", active, err)
+	}
+	// 已经停掉后再 Stop 必须是无操作而不是报错，否则 uninstall 无法重跑。
+	if err := runner.DisableAndStop(label); err != nil {
+		t.Fatalf("stopping an already-stopped service must be a no-op: %v", err)
+	}
+}
+
+// TestLaunchdRestartLoadsWhenNotYetBootstrapped 服务尚未加载时 Restart 应回退到
+// 完整加载路径，而不是因为 kickstart 找不到对象而失败。
+func TestLaunchdRestartFallsBackWhenNotLoaded(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchd is macOS-only")
+	}
+	if _, err := exec.LookPath("launchctl"); err != nil {
+		t.Skip("launchctl unavailable")
+	}
+	// 一个绝不存在的标签：kickstart 必然报 "Could not find service"，
+	// launchdNotLoaded 必须认出它，Restart 才会走 EnableAndStart。
+	_, err := runLaunchctl(5*time.Second, "kickstart", launchdTarget("com.riba2534.herdrx-absent-"+t.Name()))
+	if err == nil {
+		t.Skip("unexpectedly found the placeholder service")
+	}
+	if !launchdNotLoaded(err) {
+		t.Fatalf("launchdNotLoaded failed to classify a missing service: %v", err)
+	}
+}

--- a/internal/agentcli/service_platform_test.go
+++ b/internal/agentcli/service_platform_test.go
@@ -1,0 +1,204 @@
+package agentcli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestLaunchdPlistIsValidAndPinsGeneratedFields 验证生成的 plist 结构合法、
+// 参数逐项独立且带上运行目录。plutil 在 macOS 上是权威解析器，能抓住手写
+// XML 的语法错误；非 macOS 平台只校验内容。
+func TestLaunchdPlistIsValidAndPinsGeneratedFields(t *testing.T) {
+	binary := "/Users/tester/.local/bin/herdrx"
+	config := "/Users/tester/Library/Application Support/herdrx/config.json"
+	runtimeDir := "/Users/tester/.local/state/herdrx/run"
+	plist := GenerateLaunchdPlist(binary, config, runtimeDir)
+
+	for _, want := range []string{
+		launchdPlistMarker,
+		"<string>" + binary + "</string>",
+		"<string>serve</string>",
+		"<string>--config</string>",
+		"<string>--runtime-dir</string>",
+		"<string>" + runtimeDir + "</string>",
+		"<key>RunAtLoad</key>",
+		"<key>KeepAlive</key>",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Fatalf("generated plist is missing %q:\n%s", want, plist)
+		}
+	}
+	// 配置路径含空格，必须作为单个 <string> 出现，不能被拆成两个参数。
+	if !strings.Contains(plist, "<string>"+config+"</string>") {
+		t.Fatalf("config path was not kept as one argument:\n%s", plist)
+	}
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	if _, err := exec.LookPath("plutil"); err != nil {
+		t.Skip("plutil unavailable")
+	}
+	path := filepath.Join(t.TempDir(), "probe.plist")
+	if err := os.WriteFile(path, []byte(plist), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("plutil", "-lint", path).CombinedOutput(); err != nil {
+		t.Fatalf("plutil rejected the generated plist: %v\n%s\n%s", err, out, plist)
+	}
+}
+
+// TestLaunchdPlistEscapesXMLMetacharacters 确认路径中的 & < > 被转义，
+// 否则 plist 会解析失败而服务静默起不来。
+func TestLaunchdPlistEscapesXMLMetacharacters(t *testing.T) {
+	plist := GenerateLaunchdPlist("/Users/a&b/bin/herdrx", "/Users/a&b/<cfg>/config.json", "")
+	if strings.Contains(plist, "a&b") || strings.Contains(plist, "<cfg>") {
+		t.Fatalf("XML metacharacters were not escaped:\n%s", plist)
+	}
+	for _, want := range []string{"a&amp;b", "&lt;cfg&gt;"} {
+		if !strings.Contains(plist, want) {
+			t.Fatalf("expected escaped %q in:\n%s", want, plist)
+		}
+	}
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	if _, err := exec.LookPath("plutil"); err != nil {
+		t.Skip("plutil unavailable")
+	}
+	path := filepath.Join(t.TempDir(), "escaped.plist")
+	if err := os.WriteFile(path, []byte(plist), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("plutil", "-lint", path).CombinedOutput(); err != nil {
+		t.Fatalf("escaped plist is not valid: %v\n%s", err, out)
+	}
+}
+
+// TestLaunchdPlistOmitsRuntimeDirWhenUnset 未指定运行目录时不应出现空参数。
+func TestLaunchdPlistOmitsRuntimeDirWhenUnset(t *testing.T) {
+	plist := GenerateLaunchdPlist("/bin/herdrx", "/cfg/config.json", "")
+	if strings.Contains(plist, "--runtime-dir") {
+		t.Fatalf("unset runtime dir must not appear:\n%s", plist)
+	}
+	if strings.Contains(plist, "<string></string>") {
+		t.Fatalf("empty argument leaked into ProgramArguments:\n%s", plist)
+	}
+}
+
+// TestServiceLayoutSeparatesPlatforms 锁定两个平台各自的标识、单元位置与
+// 生成物判据，并确认互不误判——把 systemd 单元当成 launchd 的生成物会导致
+// 覆盖用户文件。两个方向都在任意 CI 机器上可测。
+func TestServiceLayoutSeparatesPlatforms(t *testing.T) {
+	home := "/home/tester"
+	env := Environment{HomeDir: home, ConfigDir: filepath.Join(home, ".config", "herdrx"), RuntimeDir: filepath.Join(home, "run")}
+
+	linux := layoutFor("linux", env)
+	if linux.Label != "herdrx.service" {
+		t.Fatal(linux.Label)
+	}
+	if linux.UnitPath != filepath.Join(home, ".config", "systemd", "user", "herdrx.service") {
+		t.Fatal(linux.UnitPath)
+	}
+
+	mac := layoutFor("darwin", env)
+	if mac.Label != launchdLabel {
+		t.Fatal(mac.Label)
+	}
+	if mac.UnitPath != filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist") {
+		t.Fatal(mac.UnitPath)
+	}
+
+	config := filepath.Join(env.ConfigDir, "config.json")
+	linuxUnit := linux.Content("/bin/herdrx", config, env.RuntimeDir)
+	macUnit := mac.Content("/bin/herdrx", config, env.RuntimeDir)
+	if strings.Contains(linuxUnit, mac.Marker) {
+		t.Fatal("systemd unit must not satisfy the launchd generated-file marker")
+	}
+	if strings.Contains(macUnit, linux.Marker) {
+		t.Fatal("launchd plist must not satisfy the systemd generated-file marker")
+	}
+	if !strings.Contains(linuxUnit, linux.ConfigReference(config)) {
+		t.Fatal("systemd unit lost its own config reference")
+	}
+	if !strings.Contains(macUnit, mac.ConfigReference(config)) {
+		t.Fatal("launchd plist lost its own config reference")
+	}
+	// 不同平台的 config 引用格式不能互相匹配，否则 update 的身份校验会失效。
+	if strings.Contains(macUnit, linux.ConfigReference(config)) || strings.Contains(linuxUnit, mac.ConfigReference(config)) {
+		t.Fatal("config reference is not platform specific")
+	}
+}
+
+// TestInstallServiceUsesLaunchdLayoutOnDarwin 验证 macOS 上 InstallService
+// 写的是 LaunchAgent plist、用 launchd 标签启动，而不是 systemd 单元。
+func TestInstallServiceUsesLaunchdLayoutOnDarwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only service layout")
+	}
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "herdrx")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := &FakeServiceRunner{LingerOk: true}
+	env := Environment{
+		HomeDir:       dir,
+		ConfigDir:     filepath.Join(dir, "Library", "Application Support", "herdrx"),
+		RuntimeDir:    filepath.Join(dir, "run"),
+		ServiceRunner: runner,
+	}
+	config := filepath.Join(env.ConfigDir, "config.json")
+	result, err := InstallService(env, binary, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "Library", "LaunchAgents", launchdLabel+".plist")
+	if result.UnitPath != want {
+		t.Fatalf("expected LaunchAgent at %s, got %s", want, result.UnitPath)
+	}
+	unit := string(runner.Units[result.UnitPath])
+	if !strings.Contains(unit, launchdPlistMarker) || strings.Contains(unit, "ExecStart=") {
+		t.Fatalf("expected a launchd plist, got:\n%s", unit)
+	}
+	var started bool
+	for _, call := range runner.Calls {
+		if call == "EnableAndStart:"+launchdLabel {
+			started = true
+		}
+		if strings.Contains(call, "herdrx.service") {
+			t.Fatalf("systemd label leaked into darwin install: %v", runner.Calls)
+		}
+	}
+	if !started {
+		t.Fatalf("service was not started with the launchd label: %v", runner.Calls)
+	}
+}
+
+// TestInstallServiceRefusesForeignUnit 确认已有的自定义单元不会被覆盖。
+func TestInstallServiceRefusesForeignUnit(t *testing.T) {
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "herdrx")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	env := Environment{
+		HomeDir:       dir,
+		ConfigDir:     filepath.Join(dir, "config", "herdrx"),
+		RuntimeDir:    filepath.Join(dir, "run"),
+		ServiceRunner: &FakeServiceRunner{LingerOk: true},
+	}
+	unitPath := layoutFor(runtime.GOOS, env).UnitPath
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("hand written by the operator\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallService(env, binary, filepath.Join(env.ConfigDir, "config.json")); err == nil {
+		t.Fatal("expected refusal to overwrite a custom unit")
+	}
+}

--- a/internal/agentcli/service_test.go
+++ b/internal/agentcli/service_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -81,16 +82,20 @@ func TestInstallService_LingerWarningAndCallSequence(t *testing.T) {
 		t.Fatalf("InstallService failed: %v", err)
 	}
 
-	// 1. 验证 Linger 告警
+	// 1. 验证保活告警：每个平台给出自己的修复动作
 	if res.LingerEnabled {
 		t.Fatalf("linger must be false")
 	}
-	if !strings.Contains(res.LingerWarning, "loginctl enable-linger") {
-		t.Fatalf("expected linger warning with fix command, got: %s", res.LingerWarning)
+	wantFix := "loginctl enable-linger"
+	if runtime.GOOS == "darwin" {
+		wantFix = "launchd"
+	}
+	if !strings.Contains(res.LingerWarning, wantFix) {
+		t.Fatalf("expected keep-alive warning mentioning %q, got: %s", wantFix, res.LingerWarning)
 	}
 
 	// 2. 验证调用顺序: WriteUnitFile -> DaemonReload -> EnableAndStart
-	expectedSuffixes := []string{"WriteUnitFile", "DaemonReload", "EnableAndStart:herdrx.service"}
+	expectedSuffixes := []string{"WriteUnitFile", "DaemonReload", "EnableAndStart:" + ServiceLabel(env)}
 	callIdx := 0
 	for _, call := range fakeRunner.Calls {
 		if strings.HasPrefix(call, "CheckLinger") {
@@ -105,13 +110,24 @@ func TestInstallService_LingerWarningAndCallSequence(t *testing.T) {
 	// 3. 验证 Unit 文件内容安全性与完整性
 	unitBytes := fakeRunner.Units[res.UnitPath]
 	unitStr := string(unitBytes)
-	for _, expectedSnippet := range []string{
+	expectedSnippets := []string{
 		`ExecStart="` + binPath + `" serve --config "` + cfgPath + `"`,
 		"Restart=always",
 		"RestartSec=3",
 		"NoNewPrivileges=true",
 		`Environment="PATH=`,
-	} {
+	}
+	if runtime.GOOS == "darwin" {
+		// launchd 用 plist 表达同样的保证：固定绝对路径、崩溃重启、注入 PATH。
+		expectedSnippets = []string{
+			"<string>" + binPath + "</string>",
+			"<string>" + cfgPath + "</string>",
+			"<key>KeepAlive</key>",
+			"<key>ThrottleInterval</key>",
+			"<key>PATH</key>",
+		}
+	}
+	for _, expectedSnippet := range expectedSnippets {
 		if !strings.Contains(unitStr, expectedSnippet) {
 			t.Fatalf("unit file missing expected snippet: %s", expectedSnippet)
 		}
@@ -122,7 +138,7 @@ func TestInstallService_LingerWarningAndCallSequence(t *testing.T) {
 		t.Fatalf("UninstallService failed: %v", err)
 	}
 	lastCalls := fakeRunner.Calls[len(fakeRunner.Calls)-3:]
-	if !strings.Contains(lastCalls[0], "DisableAndStop:herdrx.service") ||
+	if !strings.Contains(lastCalls[0], "DisableAndStop:"+ServiceLabel(env)) ||
 		!strings.Contains(lastCalls[1], "RemoveUnitFile") ||
 		!strings.Contains(lastCalls[2], "DaemonReload") {
 		t.Fatalf("unexpected uninstall call sequence: %v", lastCalls)
@@ -161,7 +177,7 @@ func TestServiceCommand_StopRestartUninstall(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("runService stop failed: %s", stderr.String())
 	}
-	if len(fakeRunner.Calls) == 0 || !strings.Contains(fakeRunner.Calls[len(fakeRunner.Calls)-1], "Stop:herdrx.service") {
+	if len(fakeRunner.Calls) == 0 || !strings.Contains(fakeRunner.Calls[len(fakeRunner.Calls)-1], "Stop:"+ServiceLabel(env)) {
 		t.Fatalf("expected runner Stop call, got: %v", fakeRunner.Calls)
 	}
 
@@ -170,7 +186,7 @@ func TestServiceCommand_StopRestartUninstall(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("runService restart failed: %s", stderr.String())
 	}
-	if len(fakeRunner.Calls) == 0 || !strings.Contains(fakeRunner.Calls[len(fakeRunner.Calls)-1], "Restart:herdrx.service") {
+	if len(fakeRunner.Calls) == 0 || !strings.Contains(fakeRunner.Calls[len(fakeRunner.Calls)-1], "Restart:"+ServiceLabel(env)) {
 		t.Fatalf("expected runner Restart call, got: %v", fakeRunner.Calls)
 	}
 
@@ -182,6 +198,9 @@ func TestServiceCommand_StopRestartUninstall(t *testing.T) {
 }
 
 func TestServiceUsesStableSymlinkAndXDGPaths(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("systemd unit layout; the launchd equivalent is covered in service_platform_test.go")
+	}
 	dir := t.TempDir()
 	realBinary := filepath.Join(dir, "releases", "v0.1.0", "herdrx")
 	stable := filepath.Join(dir, ".local", "bin", "herdrx")

--- a/internal/agentcli/smoke_test.go
+++ b/internal/agentcli/smoke_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestSubprocessSmoke_RealCLIAndIPC(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := shortTempDir(t)
 	binDir := filepath.Join(tempDir, "bin")
 	if err := os.MkdirAll(binDir, 0o700); err != nil {
 		t.Fatalf("mkdir bin: %v", err)

--- a/internal/agentcli/sockettest_test.go
+++ b/internal/agentcli/sockettest_test.go
@@ -1,0 +1,36 @@
+package agentcli
+
+import (
+	"net"
+	"testing"
+
+	"github.com/riba2534/herdrx/internal/testpaths"
+)
+
+// 这些是 internal/testpaths 的包内别名。Unix socket 路径长度的处理规则集中在
+// 那个包里（macOS 的 TMPDIR 很长，t.TempDir() 拼上测试名容易越过 103 字节上限，
+// bind 会以「invalid argument」失败），这里只做转发，避免各包各写一份。
+
+const maxUnixSocketPath = testpaths.MaxUnixSocketPath
+
+func shortTempDir(t *testing.T) string { t.Helper(); return testpaths.ShortTempDir(t) }
+
+func requireSocketPath(t *testing.T, path string) string {
+	t.Helper()
+	return testpaths.RequireSocketPath(t, path)
+}
+
+func listenShortUnix(t *testing.T, dir, name string) (net.Listener, string) {
+	t.Helper()
+	return testpaths.ListenShortUnix(t, dir, name)
+}
+
+// TestShortTempDirFitsUnixSocket 自检：夹具给出的目录必须真的能放下 socket，
+// 否则后面所有依赖它的测试都会以难以理解的方式失败。
+func TestShortTempDirFitsUnixSocket(t *testing.T) {
+	dir := shortTempDir(t)
+	_, path := listenShortUnix(t, dir, "control.sock")
+	if len(path) > maxUnixSocketPath {
+		t.Fatalf("short temp dir still produced an over-long path: %s", path)
+	}
+}

--- a/internal/agentcli/sockettest_test.go
+++ b/internal/agentcli/sockettest_test.go
@@ -1,8 +1,10 @@
 package agentcli
 
 import (
+	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/riba2534/herdrx/internal/testpaths"
 )
@@ -33,4 +35,14 @@ func TestShortTempDirFitsUnixSocket(t *testing.T) {
 	if len(path) > maxUnixSocketPath {
 		t.Fatalf("short temp dir still produced an over-long path: %s", path)
 	}
+}
+
+// fixtureCommandRunner 供依赖 mock Herdr 脚本的测试使用。
+//
+// DefaultEnv 给生产环境的 3 秒上限是刻意的，但夹具会反复 spawn 一个 shell 脚本，
+// 而 macOS 的进程创建比 Linux 慢得多：机器负载高时 3 秒会先到，测试报
+// "command execution timed out" 而不是它真正想验证的东西。这里放宽超时，
+// 不改动被测逻辑本身。
+func fixtureCommandRunner(name string, args ...string) ([]byte, error) {
+	return RunBoundedCommand(context.Background(), 30*time.Second, 1<<20, name, args...)
 }

--- a/internal/agentcli/update.go
+++ b/internal/agentcli/update.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -296,7 +297,7 @@ func restartAndWait(env Environment, expected Readiness, configPath string, time
 	if runner == nil {
 		runner = NewRealServiceRunner()
 	}
-	if err := runner.Restart("herdrx.service"); err != nil {
+	if err := runner.Restart(ServiceLabel(env)); err != nil {
 		return err
 	}
 	return waitForReadiness(env, expected, configPath, timeout)
@@ -337,15 +338,16 @@ func waitForReadiness(env Environment, expected Readiness, configPath string, ti
 func prepareUpdateService(env Environment, stable, configPath string) error {
 	// Only repair the generated unit, preserving the chosen identity path. A
 	// custom unit must be reviewed by its owner instead of silently overwritten.
-	path := serviceUnitPath(env)
+	layout := layoutFor(runtime.GOOS, env)
+	path := layout.UnitPath
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("read herdrx.service; first run herdrx setup: %w", err)
+		return fmt.Errorf("read %s; first run herdrx setup: %w", layout.Label, err)
 	}
-	if !strings.Contains(string(raw), "Description=herdrx remote access agent") || !strings.Contains(string(raw), " --config "+systemdArgument(configPath)) {
-		return errors.New("service is custom or uses another config; use the matching --config and generated herdrx.service")
+	if !strings.Contains(string(raw), layout.Marker) || !strings.Contains(string(raw), layout.ConfigReference(configPath)) {
+		return fmt.Errorf("service is custom or uses another config; use the matching --config and generated %s", layout.Label)
 	}
-	desired := GenerateSystemdUnit(stable, configPath, env.RuntimeDir)
+	desired := layout.Content(stable, configPath, env.RuntimeDir)
 	if string(raw) == desired {
 		return nil
 	}

--- a/internal/agentcli/update_test.go
+++ b/internal/agentcli/update_test.go
@@ -45,8 +45,15 @@ func (r *processUpdateRunner) stop() {
 	}
 	r.process = nil
 }
+
+// expectedServiceLabel 是本平台服务的标识，由 layoutFor 给出同一个来源，
+// 避免夹具和实现各写一份而漂移。
+var expectedServiceLabel = layoutFor(runtime.GOOS, Environment{}).Label
+
 func (r *processUpdateRunner) Restart(name string) error {
-	if name != "herdrx.service" {
+	// 期望的标识随平台变化（systemd 单元名 / launchd 标签），但仍必须精确匹配，
+	// 以免 update 误重启别的服务。
+	if name != expectedServiceLabel {
 		return fmt.Errorf("unexpected service %s", name)
 	}
 	r.restarts++
@@ -119,13 +126,15 @@ func TestCLIUpdate_RealProcessesRollbackAndRevocation(t *testing.T) {
 	oldBytes := buildVersionCLI(t, stable, "v0.1.0")
 	nextPath := filepath.Join(dir, "next")
 	nextBytes := buildVersionCLI(t, nextPath, "v0.2.0")
-	unit := serviceUnitPath(env)
+	// 按本平台的服务布局写单元：在 macOS 上放 systemd 单元会被 update 正确拒绝。
+	layout := layoutFor(runtime.GOOS, env)
+	unit := layout.UnitPath
 	os.MkdirAll(filepath.Dir(unit), 0o700)
-	os.WriteFile(unit, []byte(GenerateSystemdUnit(stable, configPath, env.RuntimeDir)), 0o600)
+	os.WriteFile(unit, []byte(layout.Content(stable, configPath, env.RuntimeDir)), 0o600)
 	runner := &processUpdateRunner{stable: stable, config: configPath, run: env.RuntimeDir}
 	env.ServiceRunner = runner
 	defer runner.stop()
-	if err := runner.Restart("herdrx.service"); err != nil {
+	if err := runner.Restart(layout.Label); err != nil {
 		t.Fatal(err)
 	}
 	current, err := probeExecutable(env, stable, configPath)

--- a/internal/herdr/local.go
+++ b/internal/herdr/local.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/riba2534/herdrx/internal/herdrpaths"
 )
 
 var publicID = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9:._-]{0,127}$`)
@@ -26,16 +28,16 @@ type LocalEndpoint struct {
 }
 
 func NewLocalEndpoint(binary, sessionName string) (*LocalEndpoint, error) {
-	configDir, err := os.UserConfigDir()
+	herdrDir, err := herdrpaths.HerdrDir()
 	if err != nil {
-		return nil, fmt.Errorf("resolve user config directory: %w", err)
+		return nil, fmt.Errorf("resolve herdr config directory: %w", err)
 	}
-	socket := filepath.Join(configDir, "herdr", "herdr.sock")
+	socket := filepath.Join(herdrDir, "herdr.sock")
 	if sessionName != "" {
 		if !publicID.MatchString(sessionName) {
 			return nil, fmt.Errorf("invalid herdr session name")
 		}
-		socket = filepath.Join(configDir, "herdr", "sessions", sessionName, "herdr.sock")
+		socket = filepath.Join(herdrDir, "sessions", sessionName, "herdr.sock")
 	}
 	return &LocalEndpoint{Binary: binary, SocketPath: socket, SessionName: sessionName}, nil
 }
@@ -122,7 +124,7 @@ func (e *LocalEndpoint) OpenTerminal(ctx context.Context, open TerminalOpen) (Te
 }
 
 func (e *LocalEndpoint) StageImage(ctx context.Context, ext string, r io.Reader) (string, error) {
-	cacheDir, err := os.UserCacheDir()
+	cacheDir, err := herdrpaths.CacheRoot()
 	if err != nil || cacheDir == "" {
 		cacheDir = filepath.Join(os.TempDir(), "herdrx-staging")
 	} else {

--- a/internal/herdrpaths/paths.go
+++ b/internal/herdrpaths/paths.go
@@ -19,18 +19,24 @@ import (
 //  1. XDG_CONFIG_HOME（绝对路径时）——Herdr 在所有平台都尊重它；
 //  2. macOS 上的 ~/.config——Herdr 的默认位置；
 //  3. os.UserConfigDir()——其余平台的既有行为。
+//
+// 注意 os.UserConfigDir() 在 XDG_CONFIG_HOME 被设为相对路径时会直接报错
+// （Linux 上尤其如此），所以这里必须回落到 ~/.config，否则一个非法的环境变量
+// 会让受控端完全找不到配置目录。
 func ConfigRoot() (string, error) {
 	if dir := os.Getenv("XDG_CONFIG_HOME"); filepath.IsAbs(dir) {
 		return filepath.Clean(dir), nil
 	}
-	if runtime.GOOS == "darwin" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
+	if runtime.GOOS != "darwin" {
+		if dir, err := os.UserConfigDir(); err == nil && filepath.IsAbs(dir) {
+			return dir, nil
 		}
-		return filepath.Join(home, ".config"), nil
 	}
-	return os.UserConfigDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config"), nil
 }
 
 // HerdrDir 返回 Herdr 自己的配置目录，socket 就在其中。
@@ -52,12 +58,14 @@ func CacheRoot() (string, error) {
 	if dir := os.Getenv("XDG_CACHE_HOME"); filepath.IsAbs(dir) {
 		return filepath.Clean(dir), nil
 	}
-	if runtime.GOOS == "darwin" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
+	if runtime.GOOS != "darwin" {
+		if dir, err := os.UserCacheDir(); err == nil && filepath.IsAbs(dir) {
+			return dir, nil
 		}
-		return filepath.Join(home, ".cache"), nil
 	}
-	return os.UserCacheDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cache"), nil
 }

--- a/internal/herdrpaths/paths.go
+++ b/internal/herdrpaths/paths.go
@@ -1,0 +1,63 @@
+// Package herdrpaths 解析 Herdr 自身在各平台使用的配置目录。
+//
+// 为什么不直接用 os.UserConfigDir()：在 macOS 上它固定返回
+// ~/Library/Application Support 并且完全忽略 XDG_CONFIG_HOME，而 Herdr 实际把
+// herdr.sock 放在 ~/.config/herdr/ 下。两者不一致会让受控端在 Mac 上拒绝真实
+// socket（"socket path is not allowed"），终端永远打不开。受控端必须按 Herdr
+// 的实际位置解析，而不是按 Go 的平台惯例。
+package herdrpaths
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// ConfigRoot 返回存放 herdr 配置目录的父目录。
+//
+// 解析顺序：
+//  1. XDG_CONFIG_HOME（绝对路径时）——Herdr 在所有平台都尊重它；
+//  2. macOS 上的 ~/.config——Herdr 的默认位置；
+//  3. os.UserConfigDir()——其余平台的既有行为。
+func ConfigRoot() (string, error) {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); filepath.IsAbs(dir) {
+		return filepath.Clean(dir), nil
+	}
+	if runtime.GOOS == "darwin" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".config"), nil
+	}
+	return os.UserConfigDir()
+}
+
+// HerdrDir 返回 Herdr 自己的配置目录，socket 就在其中。
+func HerdrDir() (string, error) {
+	root, err := ConfigRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "herdr"), nil
+}
+
+// CacheRoot 返回缓存根目录，语义与 ConfigRoot 一致。
+//
+// 受控端的 SSH 分支已经用 ${XDG_CACHE_HOME:-$HOME/.cache} 组装远端暂存目录，
+// 而 os.UserCacheDir() 在 macOS 上返回 ~/Library/Caches 且忽略 XDG_CACHE_HOME。
+// 两条路径必须落到同一处，否则同一台 Mac 经本机接入和经 SSH 接入会把图片暂存到
+// 不同目录。
+func CacheRoot() (string, error) {
+	if dir := os.Getenv("XDG_CACHE_HOME"); filepath.IsAbs(dir) {
+		return filepath.Clean(dir), nil
+	}
+	if runtime.GOOS == "darwin" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".cache"), nil
+	}
+	return os.UserCacheDir()
+}

--- a/internal/herdrpaths/paths_test.go
+++ b/internal/herdrpaths/paths_test.go
@@ -29,7 +29,8 @@ func TestConfigRootHonorsXDGOverride(t *testing.T) {
 }
 
 // TestConfigRootIgnoresRelativeXDG 相对路径的 XDG_CONFIG_HOME 按规范应被忽略，
-// 否则 socket 路径会依赖进程的工作目录。
+// 否则 socket 路径会依赖进程的工作目录。os.UserConfigDir() 在这种情况下会直接
+// 报错，所以必须确认我们回落到了一个可用的绝对路径而不是把错误透出去。
 func TestConfigRootIgnoresRelativeXDG(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "relative/path")
 	root, err := ConfigRoot()
@@ -41,6 +42,29 @@ func TestConfigRootIgnoresRelativeXDG(t *testing.T) {
 	}
 	if !filepath.IsAbs(root) {
 		t.Fatalf("config root must be absolute, got %s", root)
+	}
+}
+
+// TestCacheRootHonorsXDGAndStaysAbsolute 缓存目录与配置目录同规则：SSH 分支
+// 已经在用 ${XDG_CACHE_HOME:-$HOME/.cache}，本机分支必须落到同一处。
+func TestCacheRootHonorsXDGAndStaysAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+	root, err := CacheRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != dir {
+		t.Fatalf("expected XDG cache override %s, got %s", dir, root)
+	}
+
+	t.Setenv("XDG_CACHE_HOME", "relative/cache")
+	root, err = CacheRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(root) || root == "relative/cache" {
+		t.Fatalf("relative XDG_CACHE_HOME must fall back to an absolute path, got %s", root)
 	}
 }
 

--- a/internal/herdrpaths/paths_test.go
+++ b/internal/herdrpaths/paths_test.go
@@ -1,0 +1,70 @@
+package herdrpaths
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestConfigRootHonorsXDGOverride XDG_CONFIG_HOME 在所有平台都必须优先，
+// 测试夹具和自定义部署都依赖它。
+func TestConfigRootHonorsXDGOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	root, err := ConfigRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != dir {
+		t.Fatalf("expected XDG override %s, got %s", dir, root)
+	}
+	herdrDir, err := HerdrDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if herdrDir != filepath.Join(dir, "herdr") {
+		t.Fatalf("unexpected herdr dir: %s", herdrDir)
+	}
+}
+
+// TestConfigRootIgnoresRelativeXDG 相对路径的 XDG_CONFIG_HOME 按规范应被忽略，
+// 否则 socket 路径会依赖进程的工作目录。
+func TestConfigRootIgnoresRelativeXDG(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "relative/path")
+	root, err := ConfigRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root == "relative/path" {
+		t.Fatal("relative XDG_CONFIG_HOME must be ignored")
+	}
+	if !filepath.IsAbs(root) {
+		t.Fatalf("config root must be absolute, got %s", root)
+	}
+}
+
+// TestDarwinDefaultsToDotConfig macOS 上必须解析到 ~/.config，因为 Herdr 把
+// herdr.sock 放在那里；用 os.UserConfigDir() 的 ~/Library/Application Support
+// 会让受控端拒绝真实 socket，终端打不开。
+func TestDarwinDefaultsToDotConfig(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only default")
+	}
+	t.Setenv("XDG_CONFIG_HOME", "")
+	root, err := ConfigRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != filepath.Join(home, ".config") {
+		t.Fatalf("expected ~/.config on darwin, got %s", root)
+	}
+	// 明确锁定「不是 Go 的平台惯例」这一点，防止有人改回 os.UserConfigDir()。
+	if apple, err := os.UserConfigDir(); err == nil && root == apple {
+		t.Fatalf("darwin must not use %s for herdr's socket directory", apple)
+	}
+}

--- a/internal/httpapi/auth_regression_test.go
+++ b/internal/httpapi/auth_regression_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/riba2534/herdrx/internal/config"
 	"github.com/riba2534/herdrx/internal/secure"
 	"github.com/riba2534/herdrx/internal/store"
+	"github.com/riba2534/herdrx/internal/testpaths"
 	"io"
 	"log/slog"
 	"net"
@@ -28,7 +29,7 @@ import (
 // All data and identities are isolated; real password hashing is covered by the existing HTTP flow test.
 func authFixture(t *testing.T, openRegistration ...bool) (*API, *store.Store, *httptest.Server, *http.Client, map[string]any) {
 	t.Helper()
-	dir := t.TempDir()
+	dir := testpaths.ShortTempDir(t)
 	db, err := store.Open(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -149,7 +150,7 @@ func TestAuthRegressionRegistrationRejectsInvalidInviteBeforeHash(t *testing.T) 
 
 func fakeHerdrSocket(t *testing.T) *atomic.Int32 {
 	t.Helper()
-	dir := t.TempDir()
+	dir := testpaths.ShortTempDir(t)
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	if err := os.MkdirAll(filepath.Join(dir, "herdr"), 0700); err != nil {
 		t.Fatal(err)

--- a/internal/httpapi/input_queue_test.go
+++ b/internal/httpapi/input_queue_test.go
@@ -15,10 +15,11 @@ import (
 	"github.com/riba2534/herdrx/internal/hostruntime"
 	"github.com/riba2534/herdrx/internal/store"
 	"github.com/riba2534/herdrx/internal/terminalwire"
+	"github.com/riba2534/herdrx/internal/testpaths"
 )
 
 func TestSlowInputDoesNotBlockWebSocketAndFailureStopsPendingInput(t *testing.T) {
-	dir := t.TempDir()
+	dir := testpaths.ShortTempDir(t)
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	if err := os.MkdirAll(filepath.Join(dir, "herdr"), 0700); err != nil {
 		t.Fatal(err)

--- a/internal/httpapi/push_regression_test.go
+++ b/internal/httpapi/push_regression_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/riba2534/herdrx/internal/store"
+	"github.com/riba2534/herdrx/internal/testpaths"
 )
 
 // Exercise the actual poller and notification transport, including work already
@@ -36,7 +37,7 @@ func TestDisableStopsPushCollectionAndQueuedDelivery(t *testing.T) {
 			if err := db.CreateHost(ctx, host); err != nil {
 				t.Fatal(err)
 			}
-			dir := t.TempDir()
+			dir := testpaths.ShortTempDir(t)
 			t.Setenv("XDG_CONFIG_HOME", dir)
 			if err := os.MkdirAll(filepath.Join(dir, "herdr"), 0700); err != nil {
 				t.Fatal(err)

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/riba2534/herdrx/internal/config"
 	"github.com/riba2534/herdrx/internal/secure"
 	"github.com/riba2534/herdrx/internal/store"
+	"github.com/riba2534/herdrx/internal/testpaths"
 )
 
 func TestBootstrapInviteAndTenantHostFlow(t *testing.T) {
@@ -232,7 +233,7 @@ func postMultipart(t *testing.T, client *http.Client, url, csrf, fieldName, file
 func TestPasteImageEndpointAndValidation(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("XDG_CACHE_HOME", dataDir)
-	configDir := t.TempDir()
+	configDir := testpaths.ShortTempDir(t)
 	t.Setenv("XDG_CONFIG_HOME", configDir)
 	if err := os.MkdirAll(filepath.Join(configDir, "herdr"), 0o700); err != nil {
 		t.Fatal(err)

--- a/internal/httpapi/tailcat_test.go
+++ b/internal/httpapi/tailcat_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/riba2534/herdrx/internal/push"
 	"github.com/riba2534/herdrx/internal/secure"
 	"github.com/riba2534/herdrx/internal/store"
+	"github.com/riba2534/herdrx/internal/testpaths"
 	"github.com/riba2534/herdrx/internal/tunnel"
 	"github.com/tailscale/tailcat"
 	"golang.org/x/crypto/ssh"
@@ -128,11 +129,7 @@ func TestTailcatEnrollment_SSRFAndSizeValidation(t *testing.T) {
 func TestTailcatEnrollment_EndToEndWithLocalDERP(t *testing.T) {
 	// A Unix socket in an isolated remote configuration supplies a stable pane.
 	// The formal Tailcat server forwards the real SSH stream to this socket.
-	remoteDir, err := os.MkdirTemp("", "herdrx-restore-peer-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(remoteDir)
+	remoteDir := testpaths.ShortTempDir(t)
 	t.Setenv("XDG_CONFIG_HOME", remoteDir)
 	if err := os.Mkdir(filepath.Join(remoteDir, "herdr"), 0700); err != nil {
 		t.Fatal(err)

--- a/internal/testpaths/testpaths.go
+++ b/internal/testpaths/testpaths.go
@@ -1,0 +1,60 @@
+// Package testpaths 为测试提供足够短的临时目录，用于放置 Unix domain socket。
+//
+// 为什么需要它：sockaddr_un.sun_path 有硬上限（macOS 104 字节含结尾 NUL，
+// Linux 108）。而 t.TempDir() 会把测试名拼进路径，macOS 的 TMPDIR 本身又有
+// 49 个字符（/var/folders/<2>/<28>/T/），两者相加经常越界，bind 会返回
+// 「invalid argument」——看起来像功能坏了，其实只是路径太长。
+//
+// 这个包只被测试使用，放在 internal 下随源码走，不进入发布产物。
+package testpaths
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// MaxUnixSocketPath 取两个平台的最小上限，让同一套断言到处成立。
+const MaxUnixSocketPath = 103
+
+// ShortTempDir 返回一个短到能放 Unix socket 的临时目录，测试结束自动清理。
+func ShortTempDir(t *testing.T) string {
+	t.Helper()
+	root := os.TempDir()
+	if runtime.GOOS == "darwin" {
+		// /tmp（→ /private/tmp）比 per-user 的 TMPDIR 短得多。
+		if info, err := os.Stat("/tmp"); err == nil && info.IsDir() {
+			root = "/tmp"
+		}
+	}
+	dir, err := os.MkdirTemp(root, "hx")
+	if err != nil {
+		t.Fatalf("create short temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// RequireSocketPath 在路径超限时立即失败并说明原因，而不是把一个语义不明的
+// bind 错误留给调用方。
+func RequireSocketPath(t *testing.T, path string) string {
+	t.Helper()
+	if len(path) > MaxUnixSocketPath {
+		t.Fatalf("unix socket path is %d bytes, over the %d-byte limit: %s", len(path), MaxUnixSocketPath, path)
+	}
+	return path
+}
+
+// ListenShortUnix 在短路径下监听一个 Unix socket。
+func ListenShortUnix(t *testing.T, dir, name string) (net.Listener, string) {
+	t.Helper()
+	path := RequireSocketPath(t, filepath.Join(dir, name))
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen unix socket at %s: %v", path, err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	return listener, path
+}

--- a/internal/tunnel/ssh_access_test.go
+++ b/internal/tunnel/ssh_access_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/riba2534/herdrx/internal/agent"
 	"github.com/riba2534/herdrx/internal/secure"
+	"github.com/riba2534/herdrx/internal/testpaths"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -71,11 +72,7 @@ func isolatedClientSocket(t *testing.T) ([]byte, *atomic.Int32) {
 	t.Helper()
 	// A short temporary XDG path avoids sockaddr_un limits without accessing
 	// the test runner's actual Herdr configuration or existing sessions.
-	dir, err := os.MkdirTemp("", "herdrx-tunnel-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := testpaths.ShortTempDir(t)
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	path := filepath.Join(dir, "herdr", "sessions", "isolated", "herdr-client.sock")
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/netip"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -403,8 +404,10 @@ func TestTwoPhaseProtocol_LiveDERPEndToEnd(t *testing.T) {
 			t.Fatalf("uname failed on active channel: %v", err)
 		}
 		actSess.Close()
-		if !strings.Contains(actOut.String(), "linux amd64") {
-			t.Fatalf("unexpected uname output: %s", actOut.String())
+		// 受控端按真实平台回报 GOOS/GOARCH，断言不能写死 linux amd64。
+		wantUname := runtime.GOOS + " " + runtime.GOARCH
+		if !strings.Contains(actOut.String(), wantUname) {
+			t.Fatalf("unexpected uname output: %s (want %s)", actOut.String(), wantUname)
 		}
 	}
 }

--- a/scripts/build-cli-release.py
+++ b/scripts/build-cli-release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build reproducible Linux CLI archives and GitHub Release assets."""
+"""Build reproducible Linux and macOS CLI archives and GitHub Release assets."""
 import argparse
 import gzip
 import hashlib
@@ -43,23 +43,24 @@ def main():
     ).encode()
     metadata = {"version": args.version, "revision": revision, "source_dirty": dirty, "platforms": []}
     with tempfile.TemporaryDirectory(prefix="herdrx-cli-release-") as build_dir:
-        for arch in ("amd64", "arm64"):
-            binary = Path(build_dir) / f"herdrx-{arch}"
-            env = {**os.environ, "CGO_ENABLED": "0", "GOOS": "linux", "GOARCH": arch}
-            subprocess.run(["go", "build", "-trimpath", "-buildvcs=false", "-ldflags", f"-s -w -X main.version={args.version}", "-o", str(binary), "./cmd/herdrx"], cwd=ROOT, env=env, check=True)
-            data = binary.read_bytes()
-            manifest_name = f"herdrx-linux-{arch}.manifest.json"
-            manifest = release_signing.sign(data, args.version, arch, signing_key, created)
-            (output / manifest_name).write_text(json.dumps(manifest, indent=2) + "\n")
-            archive_name = f"herdrx-linux-{arch}.tar.gz"
-            with (output / archive_name).open("wb") as stream:
-                with gzip.GzipFile(filename="", mode="wb", fileobj=stream, mtime=0) as compressed:
-                    with tarfile.open(fileobj=compressed, mode="w") as archive:
-                        for name, content, mode in (("herdrx", data, 0o755), ("VERSION", (args.version + "\n").encode(), 0o644), ("README.md", guide, 0o644), ("LICENSE", (ROOT / "LICENSE").read_bytes(), 0o644), ("THIRD_PARTY_NOTICES.md", (ROOT / "THIRD_PARTY_NOTICES.md").read_bytes(), 0o644)):
-                            member = tarfile.TarInfo(name)
-                            member.size, member.mode, member.mtime = len(content), mode, 0
-                            archive.addfile(member, io.BytesIO(content))
-            metadata["platforms"].append({"os": "linux", "arch": arch, "asset": archive_name, "manifest": manifest_name, "binary_sha256": hashlib.sha256(data).hexdigest()})
+        for goos in ("linux", "darwin"):
+            for arch in ("amd64", "arm64"):
+                binary = Path(build_dir) / f"herdrx-{goos}-{arch}"
+                env = {**os.environ, "CGO_ENABLED": "0", "GOOS": goos, "GOARCH": arch}
+                subprocess.run(["go", "build", "-trimpath", "-buildvcs=false", "-ldflags", f"-s -w -X main.version={args.version}", "-o", str(binary), "./cmd/herdrx"], cwd=ROOT, env=env, check=True)
+                data = binary.read_bytes()
+                manifest_name = f"herdrx-{goos}-{arch}.manifest.json"
+                manifest = release_signing.sign(data, args.version, arch, signing_key, created, goos)
+                (output / manifest_name).write_text(json.dumps(manifest, indent=2) + "\n")
+                archive_name = f"herdrx-{goos}-{arch}.tar.gz"
+                with (output / archive_name).open("wb") as stream:
+                    with gzip.GzipFile(filename="", mode="wb", fileobj=stream, mtime=0) as compressed:
+                        with tarfile.open(fileobj=compressed, mode="w") as archive:
+                            for name, content, mode in (("herdrx", data, 0o755), ("VERSION", (args.version + "\n").encode(), 0o644), ("README.md", guide, 0o644), ("LICENSE", (ROOT / "LICENSE").read_bytes(), 0o644), ("THIRD_PARTY_NOTICES.md", (ROOT / "THIRD_PARTY_NOTICES.md").read_bytes(), 0o644)):
+                                member = tarfile.TarInfo(name)
+                                member.size, member.mode, member.mtime = len(content), mode, 0
+                                archive.addfile(member, io.BytesIO(content))
+                metadata["platforms"].append({"os": goos, "arch": arch, "asset": archive_name, "manifest": manifest_name, "binary_sha256": hashlib.sha256(data).hexdigest()})
     shutil.copyfile(ROOT / "install-herdrx.sh", output / "install-herdrx.sh")
     (output / "README-CLI.md").write_bytes(guide)
     shutil.copyfile(release_signing.PUBLIC_KEY_FILE, output / "RELEASE-PUBLIC-KEY")
@@ -68,7 +69,7 @@ def main():
     (output / "release.json").write_text(json.dumps(metadata, indent=2) + "\n")
     checksums = [f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n" for path in sorted(output.iterdir()) if path.is_file()]
     (output / "SHA256SUMS").write_text("".join(checksums))
-    print(f"Built herdrx {args.version}: signed Linux amd64/arm64, installer, guide and SHA256SUMS")
+    print(f"Built herdrx {args.version}: signed Linux and macOS amd64/arm64, installer, guide and SHA256SUMS")
 
 
 if __name__ == "__main__":

--- a/scripts/release_signing.py
+++ b/scripts/release_signing.py
@@ -38,8 +38,8 @@ def canonical(manifest):
     return json.dumps(ordered, separators=(",", ":"), ensure_ascii=True).encode()
 
 
-def sign(binary, version, arch, key, created):
-    manifest = dict(zip(FIELDS, (version, "linux", arch, hashlib.sha256(binary).hexdigest(), 1, 1, 1, 1,
+def sign(binary, version, arch, key, created, goos="linux"):
+    manifest = dict(zip(FIELDS, (version, goos, arch, hashlib.sha256(binary).hexdigest(), 1, 1, 1, 1,
                                  created.strftime("%Y-%m-%dT%H:%M:%SZ"), (created + timedelta(days=180)).strftime("%Y-%m-%dT%H:%M:%SZ"), "")))
     # pkeyutl's Ed25519 one-shot interface requires a regular input file.
     with tempfile.TemporaryDirectory(prefix="herdrx-release-sign-") as temporary:
@@ -48,14 +48,15 @@ def sign(binary, version, arch, key, created):
         signature = subprocess.check_output(["openssl", "pkeyutl", "-sign", "-rawin", "-inkey", str(key), "-in", str(payload)], stderr=subprocess.PIPE)
     assert len(signature) == 64
     manifest["signature"] = signature.hex()
-    verify(manifest, binary, version, arch)
+    verify(manifest, binary, version, arch, goos)
     return manifest
 
 
-def verify(manifest, binary, version, arch):
+def verify(manifest, binary, version, arch, goos="linux"):
     payload = canonical(manifest)
     assert VERSION.fullmatch(version) and manifest["version"] == version
-    assert manifest["goos"] == "linux" and manifest["goarch"] == arch and arch in ("amd64", "arm64")
+    assert goos in ("linux", "darwin"), "unsupported target platform"
+    assert manifest["goos"] == goos and manifest["goarch"] == arch and arch in ("amd64", "arm64")
     assert manifest["sha256"] == hashlib.sha256(binary).hexdigest()
     assert 0 < len(binary) <= 128 << 20
     assert all(type(manifest[k]) is int and manifest[k] == 1 for k in ("min_proto", "max_proto", "min_state", "max_state"))

--- a/scripts/test-cli-installer.py
+++ b/scripts/test-cli-installer.py
@@ -49,8 +49,8 @@ shutil.copyfile(source, args[args.index('-o') + 1])
         self.env = {**os.environ, "PATH": str(self.tools) + ":" + os.environ["PATH"], "FIXTURE_RELEASE": str(self.downloads), "FIXTURE_CALLS": str(self.calls)}
         self.package()
 
-    def package(self, arch="amd64", version="v0.1.0-rc.1", binary_version=None, symlink=False):
-        name = f"herdrx-linux-{arch}.tar.gz"
+    def package(self, arch="amd64", version="v0.1.0-rc.1", binary_version=None, symlink=False, goos="linux"):
+        name = f"herdrx-{goos}-{arch}.tar.gz"
         with tarfile.open(self.downloads / name, "w:gz") as archive:
             for filename, value in (("herdrx", f'#!/bin/sh\n[ "$1" = version ] || exit 9\nprintf "herdrx {binary_version or version}\\n"\n'), ("VERSION", version + "\n")):
                 member = tarfile.TarInfo(filename)
@@ -96,6 +96,26 @@ shutil.copyfile(source, args[args.index('-o') + 1])
         self.run_install()
         self.assertIn("/latest/download/herdrx-linux-arm64.tar.gz", self.calls.read_text())
 
+    def test_macos_downloads_darwin_assets(self):
+        for machine, arch in (("arm64", "arm64"), ("x86_64", "amd64")):
+            with self.subTest(machine=machine):
+                self.setUp()
+                self.env["FIXTURE_OS"] = "Darwin"
+                self.env["FIXTURE_ARCH"] = machine
+                self.package(arch=arch, goos="darwin")
+                self.run_install()
+                calls = self.calls.read_text()
+                self.assertIn(f"/latest/download/herdrx-darwin-{arch}.tar.gz", calls)
+                # 绝不能在 macOS 上抓 Linux 附件：装上去无法执行。
+                self.assertNotIn("herdrx-linux-", calls)
+
+    def test_macos_missing_asset_keeps_installed_binary(self):
+        # 只发布了 Linux 附件时，macOS 必须失败并保留原有 CLI，不能装错架构。
+        self.env["FIXTURE_OS"] = "Darwin"
+        self.env["FIXTURE_ARCH"] = "arm64"
+        self.run_install(success=False)
+        self.assert_unchanged()
+
     def test_bad_checksum_keeps_installed_binary(self):
         (self.downloads / "herdrx-linux-amd64.tar.gz").write_bytes(b"broken")
         self.run_install(success=False)
@@ -128,7 +148,7 @@ shutil.copyfile(source, args[args.index('-o') + 1])
         self.assert_unchanged()
 
     def test_invalid_platform_arch_or_version_does_not_download(self):
-        for key, value in (("FIXTURE_OS", "Darwin"), ("FIXTURE_ARCH", "riscv64")):
+        for key, value in (("FIXTURE_OS", "FreeBSD"), ("FIXTURE_ARCH", "riscv64")):
             self.env[key] = value
             self.run_install(success=False)
             self.env.pop(key)

--- a/scripts/verify-cli-release.py
+++ b/scripts/verify-cli-release.py
@@ -12,7 +12,24 @@ import tempfile
 
 import release_signing
 
-ASSETS = {"herdrx-linux-amd64.tar.gz", "herdrx-linux-arm64.tar.gz", "herdrx-linux-amd64.manifest.json", "herdrx-linux-arm64.manifest.json", "RELEASE-PUBLIC-KEY", "LICENSE", "THIRD_PARTY_NOTICES.md", "sbom.cdx.json", "install-herdrx.sh", "README-CLI.md", "release.json", "SHA256SUMS"}
+PLATFORMS = {("linux", "amd64"), ("linux", "arm64"), ("darwin", "amd64"), ("darwin", "arm64")}
+ASSETS = {f"herdrx-{goos}-{arch}.{suffix}" for goos, arch in PLATFORMS for suffix in ("tar.gz", "manifest.json")} | {
+    "RELEASE-PUBLIC-KEY", "LICENSE", "THIRD_PARTY_NOTICES.md", "sbom.cdx.json", "install-herdrx.sh", "README-CLI.md", "release.json", "SHA256SUMS"}
+
+# Mach-O 64-bit little-endian magic (cffaedfe) plus the CPU types Go emits.
+MACHO_MAGIC = bytes.fromhex("cffaedfe")
+MACHO_CPU = {"amd64": 0x01000007, "arm64": 0x0100000C}
+ELF_MACHINE = {"amd64": 62, "arm64": 183}
+
+
+def assert_binary_format(binary, goos, arch):
+    """Reject a binary built for the wrong OS or CPU, whatever the file name claims."""
+    if goos == "linux":
+        assert binary[:4] == b"\x7fELF", "linux asset is not an ELF binary"
+        assert int.from_bytes(binary[18:20], "little") == ELF_MACHINE[arch], "ELF CPU does not match the asset name"
+        return
+    assert binary[:4] == MACHO_MAGIC, "darwin asset is not a 64-bit little-endian Mach-O binary"
+    assert int.from_bytes(binary[4:8], "little") == MACHO_CPU[arch], "Mach-O CPU does not match the asset name"
 
 
 def verify(directory):
@@ -28,12 +45,15 @@ def verify(directory):
         hashes[name] = digest
     metadata = json.loads((directory / "release.json").read_text())
     assert (directory / "RELEASE-PUBLIC-KEY").read_bytes() == release_signing.PUBLIC_KEY_FILE.read_bytes(), "downloaded key differs from trusted source"
-    assert {p["arch"] for p in metadata["platforms"]} == {"amd64", "arm64"}
-    native = {"x86_64": "amd64", "aarch64": "arm64"}.get(platform.machine())
-    assert native and platform.system() == "Linux", "native smoke check requires supported Linux CPU"
+    assert {(p["os"], p["arch"]) for p in metadata["platforms"]} == PLATFORMS, "release must cover linux and darwin on amd64/arm64"
+    native_arch = {"x86_64": "amd64", "amd64": "amd64", "aarch64": "arm64", "arm64": "arm64"}.get(platform.machine())
+    native_os = {"Linux": "linux", "Darwin": "darwin"}.get(platform.system())
+    assert native_arch and native_os, "native smoke check requires a supported Linux or macOS CPU"
+    smoke_ran = False
     for entry in metadata["platforms"]:
-        assert entry["asset"] == f"herdrx-linux-{entry['arch']}.tar.gz"
-        assert entry["manifest"] == f"herdrx-linux-{entry['arch']}.manifest.json"
+        goos = entry["os"]
+        assert entry["asset"] == f"herdrx-{goos}-{entry['arch']}.tar.gz"
+        assert entry["manifest"] == f"herdrx-{goos}-{entry['arch']}.manifest.json"
         with tarfile.open(directory / entry["asset"], "r:gz") as archive:
             members = archive.getmembers()
             assert [m.name for m in members] == ["herdrx", "VERSION", "README.md", "LICENSE", "THIRD_PARTY_NOTICES.md"]
@@ -44,10 +64,10 @@ def verify(directory):
             binary = archive.extractfile("herdrx").read()
             assert version == metadata["version"]
             assert hashlib.sha256(binary).hexdigest() == entry["binary_sha256"]
-            release_signing.verify(json.loads((directory / entry["manifest"]).read_text()), binary, version, entry["arch"])
-            assert binary[:4] == b"\x7fELF"
-            assert int.from_bytes(binary[18:20], "little") == {"amd64": 62, "arm64": 183}[entry["arch"]]
-            if entry["arch"] == native:
+            release_signing.verify(json.loads((directory / entry["manifest"]).read_text()), binary, version, entry["arch"], goos)
+            assert_binary_format(binary, goos, entry["arch"])
+            if entry["arch"] == native_arch and goos == native_os:
+                smoke_ran = True
                 with tempfile.TemporaryDirectory(prefix="herdrx-cli-smoke-") as temporary:
                     path = Path(temporary) / "herdrx"
                     path.write_bytes(binary)
@@ -56,9 +76,11 @@ def verify(directory):
                     assert subprocess.check_output([path, "version"], text=True, env=env).strip() == f"herdrx {version}"
                     assert "setup" in subprocess.check_output([path, "--help"], text=True, env=env)
                     assert subprocess.run([path, "status", "--json"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE).returncode == 1
+    # 静默跳过原生冒烟等于没验证；必须确认本机架构那一份真的跑过。
+    assert smoke_ran, f"no asset matched {native_os}/{native_arch}; the native smoke check did not run"
     return metadata
 
 
 if __name__ == "__main__":
     result = verify(sys.argv[1])
-    print(f"CLI release {result['version']}: checksums, archive members, CPU and native version/help/offline status passed")
+    print(f"CLI release {result['version']}: checksums, archive members, binary format and native version/help/offline status passed")


### PR DESCRIPTION
关联 #1（按 CONTRIBUTING 的要求，涉及新接入方式先开 Issue 说明场景）。如果维护者决定继续维持「macOS 不在首发范围」，这个 PR 可以直接关掉——#1 里也给了「只把安装器报错写清楚」的替代方案。

## 问题

```
$ curl -fsSL .../install-herdrx.sh | sh -s -- --version v0.1.0-rc.2
This installer supports Linux. Use SSH access on other remote-host systems.
```

安装器的 `uname -s` 检查只是表层症状。Release 只发布 Linux 附件，所以单独放开这个检查会让流程改在下载那一步失败。要让 macOS 真的可用，必须同时动服务层、构建矩阵和发布校验。

## 改动

**服务管理走平台布局，不再假设 systemd。** 新增 `serviceLayout`，把标识、单元路径、单元内容、「本单元由 herdrx 生成」的判据和保活提示收在一处。macOS 用 per-user LaunchAgent + `launchctl`，沿用旧版受控端（`internal/agent/service.go`）已经建立的 `gui/<uid>` 域与 `com.riba2534.herdrx-*` 标签约定；plist 表达 systemd 单元同样的保证：绝对路径、崩溃重启、注入 PATH。`setup` / `update` / `service` / `logs` 都从布局取标识与路径，因此两个平台不会互相拿到对方的服务，也不会覆盖手写单元。`logs` 在 macOS 读 `~/Library/Logs/herdrx.log`（没有 journald）。

`layoutFor` 显式接收 `goos` 而不是直接读 `runtime.GOOS`，两个平台的单元内容与路径都能在任意一种 CI 机器上被测到，包括「systemd 单元不得满足 launchd 的生成物判据」这类互不误判的断言。

**两个真实的可移植性缺陷**（在真机上跑才暴露，不是纯粹的测试问题）：

- `allowedSocket` 和 `NewLocalEndpoint` 通过 `os.UserConfigDir()` 解析 Herdr 的 socket。它在 macOS 返回 `~/Library/Application Support` 并且忽略 `XDG_CONFIG_HOME`，而 Herdr 实际使用 `~/.config/herdr`——受控端因此拒绝真实 socket（`socket path is not allowed`），终端永远打不开。图片暂存有同样的分裂：SSH 分支已经在用 `${XDG_CACHE_HOME:-$HOME/.cache}`，本机分支却落到 `~/Library/Caches`，同一台 Mac 经不同接入方式会暂存到不同目录。新增 `internal/herdrpaths` 统一解析，并明确注释「不能用 Go 的平台惯例，要按 Herdr 的实际位置」。
- `DefaultEnv` 出于同样原因在 macOS 忽略 `XDG_CONFIG_HOME`，这也让隔离测试会逃逸到真实用户目录。

**发布链路覆盖 linux + darwin 的 amd64/arm64。** 清单记录 `goos`；校验脚本在 ELF 之外增加 Mach-O 魔数与 CPU 类型检查，原生冒烟按 runner 实际的 OS/CPU 选择，并且**在没有任何附件匹配当前 runner 时报错而不是静默跳过**——「没跑」和「跑过且通过」不能同形。

## 验证

darwin/arm64（M 系列真机）与 linux/amd64 两侧都跑过 `go vet ./...`、`go test -count=1 ./...`、`scripts/test-cli-installer.py`；`internal/agentcli` 另跑 `go test -race`。安装器测试从 8 个增加到 10 个，新增两个 macOS 用例（正确抓取 darwin 附件且绝不回退到 Linux 附件；只有 Linux 附件时必须失败并保留原有 CLI，不装错架构）。

**launchd 不是只有单元测试。** `service_launchd_test.go` 驱动真实 `launchctl` 走完 bootstrap → kickstart → 查询 → bootout，并且等待服务真的写出 marker 文件才算通过，而不是相信 `launchctl` 的退出码；同时验证重复 `EnableAndStart` 幂等、已停止的服务再 `Stop` 不报错。它用独立 HOME 和独立标签，不碰机器上真实的服务，在 Linux 和没有桌面会话的 Mac 上自动跳过。plist 另外用 `plutil -lint` 校验，并覆盖路径含 `& < >` 与空格的转义。

这个真机测试立刻抓到了我自己的一个 bug：`CheckLinger` 原本用 `launchctl print gui/<uid>` 判断图形会话，而它会打印域里全部服务（这台机器 478 个），撞上 `RunBoundedCommand` 的 64 KiB 上限后被误判成「没有图形会话」，于是**每台健康的 Mac 都会收到一条错误告警**。改用只输出一行的 `launchctl managername`（有图形会话时为 `Aqua`）。

我也独立验证了发布校验的格式判定确实有牙：四个平台组合的二进制都被正确接受，五种张冠李戴（Linux 二进制冒充 darwin、darwin 冒充 Linux、arm64 Mach-O 冒充 amd64、amd64 冒充 arm64、arm64 ELF 冒充 amd64）全部被拒绝。安装器也用本地伪造的 Release 在这台 Mac 上真跑了一遍，确认抓的是 `herdrx-darwin-arm64.tar.gz` 并安装成功、装完的二进制 `self-test` 通过。

## macOS 上的测试套件

上游 `55d3e2e` 在 macOS 上有 5 个包、18+ 个用例失败。主因不是产品缺陷而是夹具可移植性，逐条修掉：

- **Unix socket 路径超限**（多数失败的根源）。`sockaddr_un.sun_path` 在 macOS 上限 104 字节含 NUL（实测 103 可用、104 起 `bind: invalid argument`），而 `TMPDIR` 本身就有 49 字符，`t.TempDir()` 再拼上测试名很容易越界。新增 `internal/testpaths` 收敛这条规则，并在超限时直接报出「路径 N 字节，超过上限」而不是把一个语义不明的 `bind` 错误丢给调用方。
- 夹具按 systemd 写死（单元内容、服务标识、旧服务迁移路径），改为按平台布局取。
- `/bin/true` 在 macOS 不存在（只有 `/usr/bin/true`）；改为按实际存在的位置取，保留「trivially-succeeding 二进制不得被误判为 Herdr」这个原意，而不是跳过测试。
- 一处 `uname` 断言写死 `linux amd64`；实现本来就按 `runtime.GOOS/GOARCH` 如实回报，改断言而非改实现。
- `TestSetupDERPConfigIsRepeatableAndCannotMoveActiveBinding` 在**高负载的 macOS** 上会撞 `DefaultEnv` 的 3 秒外部命令上限——夹具要反复 spawn shell 脚本，而 macOS 的进程创建比 Linux 慢得多（同一测试在 Linux 上即使有 16 个满载核心也只要 0.014s）。夹具改用 30 秒 runner，生产环境保持 3 秒不变。

## 未覆盖 / 需要维护者决定

- **macOS 的服务生命周期没有进 CI。** 上面的 launchd 测试在 Linux runner 上会跳过，我是在本机 Apple Silicon 上跑的。要纳入 CI 需要加 `macos-14`（ARM64）与 `macos-13`（x86_64）runner；文档里我按现状写明了「附件目前只做格式与签名校验，未在 macOS runner 上实机运行」。
- **Intel Mac 未实机验证。** amd64 附件按同一流程构建，格式检查通过，但我没有 Intel 机器实跑。
- **签名 Release 必须由持有签名私钥的维护者产出。** `build-cli-release.py` 会校验私钥与源码固定信任根一致，我无法（也不应该）在本地产出真实签名附件，所以我验证的是构建+打包+格式判定这条链路，签名那一步只能由你验证。
- `internal/webassets/assets.go` 的 gofmt 状态是既有的，我没有改它，以免混入无关改动。
- 文档已同步：`docs/install.md`、`docs/tailcat-quickstart.md`（附件表、后台运行、日志、排障）、`docs/cli-release.md`。README 里 Linux 相关的表述指的是**工作台主机**（仍然是 Linux + Docker），未改动。
